### PR TITLE
CREATE TABLE column definition parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,14 @@ SET(LIBSQLTOAST_SOURCES
     src/column_definition.cc
     src/data_type.cc
     src/parser/column_definition.cc
+    src/parser/data_type_descriptor.cc
     src/parser/comment.cc
     src/parser/context.cc
     src/parser/error.cc
     src/parser/keyword.cc
     src/parser/identifier.cc
     src/parser/lexer.cc
+    src/parser/literal.cc
     src/parser/parse.cc
     src/parser/punctuator.cc
     src/parser/sequence.cc

--- a/include/data_type.h
+++ b/include/data_type.h
@@ -37,12 +37,23 @@ typedef struct data_type_descriptor {
     virtual const std::string to_string() = 0;
 } data_type_descriptor_t;
 
-typedef struct character_string : data_type_descriptor_t {
-    character_string() :
-        data_type_descriptor_t(DATA_TYPE_CHAR)
+typedef struct char_string : data_type_descriptor_t {
+    size_t size;
+    char_string(size_t size) :
+        data_type_descriptor_t(DATA_TYPE_CHAR),
+        size(size)
     {}
     virtual const std::string to_string();
-} character_string_t;
+} char_string_t;
+
+typedef struct varchar_string : data_type_descriptor_t {
+    size_t size;
+    varchar_string(size_t size) :
+        data_type_descriptor_t(DATA_TYPE_VARCHAR),
+        size(size)
+    {}
+    virtual const std::string to_string();
+} varchar_string_t;
 
 } // namespace sqltoast
 

--- a/src/data_type.cc
+++ b/src/data_type.cc
@@ -4,14 +4,25 @@
  * See the COPYING file in the root project directory for full text.
  */
 
+#include <sstream>
 #include <string>
 
 #include "data_type.h"
 
 namespace sqltoast {
 
-const std::string character_string_t::to_string() {
-    return std::string("CHAR");
+const std::string char_string_t::to_string() {
+    std::stringstream ss("CHAR");
+    if (size > 0)
+        ss << "(" << size << ")";
+    return ss.str();
+}
+
+const std::string varchar_string_t::to_string() {
+    std::stringstream ss("VARCHAR");
+    if (size > 0)
+        ss << "(" << size << ")";
+    return ss.str();
 }
 
 } // namespace sqltoast

--- a/src/parser/lexer.cc
+++ b/src/parser/lexer.cc
@@ -14,6 +14,7 @@
 #include "parser/comment.h"
 #include "parser/identifier.h"
 #include "parser/lexer.h"
+#include "parser/literal.h"
 #include "parser/keyword.h"
 #include "parser/punctuator.h"
 #include "parser/token.h"
@@ -29,6 +30,10 @@ bool next_token(parse_context_t& ctx) {
     if (ctx.result.code == PARSE_SYNTAX_ERROR)
         return false;
     if (token_punctuator(ctx))
+        return true;
+    if (ctx.result.code == PARSE_SYNTAX_ERROR)
+        return false;
+    if (token_literal(ctx))
         return true;
     if (ctx.result.code == PARSE_SYNTAX_ERROR)
         return false;

--- a/src/parser/literal.cc
+++ b/src/parser/literal.cc
@@ -1,0 +1,61 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#include "literal.h"
+#include "token.h"
+
+namespace sqltoast {
+
+bool token_literal(parse_context_t& ctx) {
+    parse_cursor_t start = ctx.cursor;
+    symbol_t found_sym;
+    char c = *ctx.cursor;
+    if (std::isdigit(c))
+        goto try_unsigned_numeric;
+    switch (c) {
+        default:
+            goto not_found;
+    }
+try_unsigned_numeric:
+    // read to the next separator. if all characters are numbers, this is an
+    // unsigned numeric
+    found_sym = SYMBOL_LITERAL_UNSIGNED_NUMERIC;
+    for (;;) {
+        c = *ctx.cursor++;
+        if (ctx.cursor == ctx.end_pos)
+            goto push_literal;
+        if (std::isspace(c))
+            goto push_literal;
+        if (std::isdigit(c))
+            continue;
+        switch (c) {
+            case ',':
+            case ')':
+            case '(':
+            case ';':
+                goto push_literal;
+            default:
+                goto not_found;
+        }
+    }
+push_literal:
+    ctx.cursor--;
+    {
+        token_t tok(
+            TOKEN_TYPE_LITERAL,
+            found_sym,
+            parse_position_t(start),
+            parse_position_t(ctx.cursor)
+        );
+        ctx.push_token(tok);
+    }
+    return true;
+not_found:
+    ctx.cursor = start; // rewind... we didn't find a literal
+    return false;
+}
+
+} // namespace sqltoast

--- a/src/parser/literal.h
+++ b/src/parser/literal.h
@@ -1,0 +1,21 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#ifndef SQLTOAST_PARSER_LITERAL_H
+#define SQLTOAST_PARSER_LITERAL_H
+
+#include "context.h"
+
+namespace sqltoast {
+
+// Moves the supplied parse context's cursor to the next literal found in the
+// context's input stream and adds a token with type literal to the tokens
+// stack.Returns whether a literal was found.
+bool token_literal(parse_context_t& ctx);
+
+} // namespace sqltoast
+
+#endif /* SQLTOAST_PARSER_LITERAL_H */

--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -19,13 +19,29 @@ namespace sqltoast {
 typedef bool (*parse_func_t) (parse_context_t& ctx);
 
 // Returns true if a column definition clause can be parsed from the supplied
-// token iterator. If the function returns true, then tok_it will be pointing
-// at the next token to be parsed and column_defs will have a new member (if
-// ctx.options.disable_statement_construction is false
+// token iterator. If the function returns true, column_defs will have a new
+// member (if ctx.options.disable_statement_construction is false
 bool parse_column_definition(
         parse_context_t& ctx,
         tokens_t::iterator tok_it,
         std::vector<std::unique_ptr<column_definition_t>>& column_defs);
+
+// Returns true if a data type descriptor clause can be parsed from the supplied
+// token iterator. If the function returns true, the column_def argument will
+// have its data_type attribute set to an allocated data type descriptor
+bool parse_data_type_descriptor(
+        parse_context_t& ctx,
+        tokens_t::iterator tok_it,
+        column_definition_t& column_def);
+
+// Returns true if a character string descriptor clause can be parsed from the
+// supplied token iterator. If the function returns true, the column_def
+// argument will have its data_type attribute set to an allocated char_string_t
+// or varchar_string_t descriptor
+bool parse_character_string(
+        parse_context_t& ctx,
+        tokens_t::iterator tok_it,
+        column_definition_t& column_def);
 
 } // namespace sqltoast
 

--- a/src/parser/statements/create_table.cc
+++ b/src/parser/statements/create_table.cc
@@ -173,27 +173,10 @@ bool parse_create_table(parse_context_t& ctx) {
         // list> clause. Now we expect to find one or more column or constraint
         // definitions
         tok_it = ctx.skip_comments(tok_it);
-        if (parse_column_definition(ctx, tok_it, column_defs)) {
-            tok_it = ctx.tokens.begin();
-            goto expect_column_list_close;
-        }
-        goto err_expect_column_def;
-        SQLTOAST_UNREACHABLE();
-    err_expect_column_def:
-        {
-            parse_position_t err_pos = (*(tok_it)).start;
-            std::stringstream estr;
-            if (tok_it == ctx.tokens.end()) {
-                estr << "Expected a column definition but found EOS";
-            } else {
-                cur_sym = (*tok_it).symbol;
-                estr << "Expected a column definition but found "
-                     << symbol_map::to_string(cur_sym);
-            }
-            estr << std::endl;
-            create_syntax_error_marker(ctx, estr, err_pos);
+        if (! parse_column_definition(ctx, tok_it, column_defs))
             return false;
-        }
+        tok_it = ctx.tokens.begin();
+        goto expect_column_list_close;
         SQLTOAST_UNREACHABLE();
     expect_column_list_close:
         // We get here after successfully parsing the <table element list>

--- a/src/parser/symbol.cc
+++ b/src/parser/symbol.cc
@@ -20,6 +20,7 @@ symbol_map::symbol_map_t  _init_symbol_map() {
     // Reserved keywords
     m[SYMBOL_AUTHORIZATION] = std::string("AUTHORIZATION");
     m[SYMBOL_CASCADE] = std::string("CASCADE");
+    m[SYMBOL_CHAR] = std::string("CHAR");
     m[SYMBOL_CHARACTER] = std::string("CHARACTER");
     m[SYMBOL_CREATE] = std::string("CREATE");
     m[SYMBOL_DEFAULT] = std::string("DEFAULT");
@@ -38,6 +39,7 @@ symbol_map::symbol_map_t  _init_symbol_map() {
     // Other symbols
     m[SYMBOL_IDENTIFIER] = std::string("<< identifier >>");
     m[SYMBOL_COMMENT] = std::string("<< comment >>");
+    m[SYMBOL_LITERAL_UNSIGNED_NUMERIC] = std::string("<< unsigned numeric literal >>");
 
     return m;
 }

--- a/src/parser/symbol.h
+++ b/src/parser/symbol.h
@@ -56,7 +56,8 @@ typedef enum symbol {
 
     // Other symbols
     SYMBOL_IDENTIFIER,
-    SYMBOL_COMMENT
+    SYMBOL_COMMENT,
+    SYMBOL_LITERAL_UNSIGNED_NUMERIC
 } symbol_t;
 
 struct symbol_map {


### PR DESCRIPTION
Adds more parsing breakdown of the data type descriptor clause in the column definition for CREATE TABLE statement.

Issue #8 