### PR TITLE
fully encpasulate next_token() within lexer_t

### DIFF
--- a/src/parser/column_definition.cc
+++ b/src/parser/column_definition.cc
@@ -40,35 +40,34 @@ bool parse_column_definition(
 
     // BEGIN STATE MACHINE
 
-    start:
-        // We start here. The first component of the column definition is the
-        // identifier that indicates the column name.
-        if (cur_sym == SYMBOL_IDENTIFIER) {
-            fill_lexeme(cur_tok, ident);
-            cur_tok = next_token(ctx);
-            goto create_column_def;
-        }
-        // Just return false, since callers could be looking for
-        // a constraint definition
-        return false;
-        SQLTOAST_UNREACHABLE();
-    create_column_def:
-        {
-            identifier_t col_name(ident);
-            cdef_p = std::move(std::make_unique<column_definition_t>(col_name));
-            if (! parse_data_type_descriptor(ctx, cur_tok, *cdef_p))
-                return false;
-            goto push_column_def;
-        }
-        SQLTOAST_UNREACHABLE();
-    push_column_def:
-        {
-            if (ctx.opts.disable_statement_construction)
-                return true;
-            column_defs.emplace_back(std::move(cdef_p));
+    // We start here. The first component of the column definition is the
+    // identifier that indicates the column name.
+    if (cur_sym == SYMBOL_IDENTIFIER) {
+        fill_lexeme(cur_tok, ident);
+        cur_tok = ctx.lexer.next_token();
+        goto create_column_def;
+    }
+    // Just return false, since callers could be looking for
+    // a constraint definition
+    return false;
+
+create_column_def:
+    {
+        identifier_t col_name(ident);
+        cdef_p = std::move(std::make_unique<column_definition_t>(col_name));
+        if (! parse_data_type_descriptor(ctx, cur_tok, *cdef_p))
+            return false;
+        goto push_column_def;
+    }
+    SQLTOAST_UNREACHABLE();
+push_column_def:
+    {
+        if (ctx.opts.disable_statement_construction)
             return true;
-        }
-        SQLTOAST_UNREACHABLE();
+        column_defs.emplace_back(std::move(cdef_p));
+        return true;
+    }
+    SQLTOAST_UNREACHABLE();
 }
 
 } // namespace sqltoast

--- a/src/parser/comment.cc
+++ b/src/parser/comment.cc
@@ -4,9 +4,6 @@
  * See the COPYING file in the root project directory for full text.
  */
 
-#include <sstream>
-
-#include "parser/error.h"
 #include "parser/comment.h"
 
 namespace sqltoast {
@@ -33,8 +30,7 @@ namespace sqltoast {
 // comments, because they are sometimes used to embed dialect-specific
 // triggers, are consumed as tokens.
 
-tokenize_result_t token_comment(parse_context_t& ctx) {
-    lexer_t& lex = ctx.lexer;
+tokenize_result_t token_comment(lexer_t& lex) {
     if (! lex.peek_char('/'))
         return TOKEN_NOT_FOUND;
 

--- a/src/parser/comment.cc
+++ b/src/parser/comment.cc
@@ -33,15 +33,15 @@ namespace sqltoast {
 // comments, because they are sometimes used to embed dialect-specific
 // triggers, are consumed as tokens.
 
-bool token_comment(parse_context_t& ctx) {
+tokenize_result_t token_comment(parse_context_t& ctx) {
     lexer_t& lex = ctx.lexer;
     if (! lex.peek_char('/'))
-        return false;
+        return TOKEN_NOT_FOUND;
 
     lex.cursor++;
     if (! lex.peek_char('*')) {
         lex.cursor--; // rewind
-        return false;
+        return TOKEN_NOT_FOUND;
     }
 
     parse_position_t start = lex.cursor;
@@ -51,26 +51,14 @@ bool token_comment(parse_context_t& ctx) {
     do {
         lex.cursor++;
         if (lex.cursor == lex.end_pos || (lex.cursor + 1) == lex.end_pos) {
-            goto err_no_end_marker;
+            return TOKEN_ERR_NO_CLOSING_DELIMITER;
         }
     } while (*lex.cursor != '*' || *(lex.cursor + 1) != '/');
-    goto create_token;
-
-    create_token:
     {
         parse_position_t end = lex.cursor - 1;
         lex.cursor += 2;
         lex.set_token(SYMBOL_COMMENT, start, end);
-        return true;
-    }
-
-    err_no_end_marker:
-    {
-        lex.error = ERR_NO_CLOSING_DELIMITER;
-        std::stringstream estr;
-        estr << "Expected closing */ comment marker but found EOS" << std::endl;
-        create_syntax_error_marker(ctx, estr, lex.end_pos);
-        return false;
+        return TOKEN_FOUND;
     }
 }
 

--- a/src/parser/comment.h
+++ b/src/parser/comment.h
@@ -11,9 +11,7 @@
 
 namespace sqltoast {
 
-bool token_comment(parse_context_t& ctx);
-bool token_simple_comment(parse_context_t& ctx);
-bool token_bracketed_comment(parse_context_t& ctx);
+tokenize_result_t token_comment(parse_context_t& ctx);
 
 } // namespace sqltoast
 

--- a/src/parser/comment.h
+++ b/src/parser/comment.h
@@ -7,11 +7,11 @@
 #ifndef SQLTOAST_PARSER_COMMENT_H
 #define SQLTOAST_PARSER_COMMENT_H
 
-#include "context.h"
+#include "parser/lexer.h"
 
 namespace sqltoast {
 
-tokenize_result_t token_comment(parse_context_t& ctx);
+tokenize_result_t token_comment(lexer_t& lex);
 
 } // namespace sqltoast
 

--- a/src/parser/context.h
+++ b/src/parser/context.h
@@ -31,19 +31,6 @@ typedef struct parse_context {
     {}
 } parse_context_t;
 
-// Attempts to find the next token in the parse context. If a token was found,
-// returns true, else false. If true, the parse context's tokens stack will
-// have had a token pushed onto it.
-token_t* next_token(parse_context_t& ctx);
-
-typedef enum tokenize_result {
-    TOKEN_FOUND,
-    TOKEN_NOT_FOUND,
-    TOKEN_ERR_NO_CLOSING_DELIMITER
-} tokenize_result_t;
-
-typedef tokenize_result_t (*tokenize_func_t) (parse_context_t& ctx);
-
 } // namespace sqltoast
 
 #endif /* SQLTOAST_PARSER_CONTEXT_H */

--- a/src/parser/context.h
+++ b/src/parser/context.h
@@ -36,6 +36,14 @@ typedef struct parse_context {
 // have had a token pushed onto it.
 token_t* next_token(parse_context_t& ctx);
 
+typedef enum tokenize_result {
+    TOKEN_FOUND,
+    TOKEN_NOT_FOUND,
+    TOKEN_ERR_NO_CLOSING_DELIMITER
+} tokenize_result_t;
+
+typedef tokenize_result_t (*tokenize_func_t) (parse_context_t& ctx);
+
 } // namespace sqltoast
 
 #endif /* SQLTOAST_PARSER_CONTEXT_H */

--- a/src/parser/identifier.cc
+++ b/src/parser/identifier.cc
@@ -34,7 +34,7 @@ namespace sqltoast {
 //
 // Note that whitespace will have been skipped already so that the character
 // pointed to by the parse context is guaranteed to be not whitespace.
-bool token_identifier(parse_context_t& ctx) {
+tokenize_result_t token_identifier(parse_context_t& ctx) {
     lexer_t& lex = ctx.lexer;
     parse_position_t start = lex.cursor;
     escape_mode current_escape = ESCAPE_NONE;
@@ -75,14 +75,14 @@ bool token_identifier(parse_context_t& ctx) {
 
     // if we went more than a single character, that's an
     // identifier...
-    bool res = (start != lex.cursor);
-    if (res) {
+    tokenize_result_t res = (start != lex.cursor) ? TOKEN_FOUND : TOKEN_NOT_FOUND;
+    if (res == TOKEN_FOUND) {
         lex.set_token(SYMBOL_IDENTIFIER, start, parse_position_t(lex.cursor));
     }
     return res;
 }
 
-bool token_delimited_identifier(parse_context_t& ctx, escape_mode current_escape) {
+tokenize_result_t token_delimited_identifier(parse_context_t& ctx, escape_mode current_escape) {
     lexer_t& lex = ctx.lexer;
     parse_position_t start = lex.cursor;
     char closer;
@@ -98,7 +98,7 @@ bool token_delimited_identifier(parse_context_t& ctx, escape_mode current_escape
             closer = '`';
             break;
         case ESCAPE_NONE:
-            return false;
+            return TOKEN_NOT_FOUND;
     }
     char c;
     while (lex.cursor != lex.end_pos) {
@@ -106,23 +106,13 @@ bool token_delimited_identifier(parse_context_t& ctx, escape_mode current_escape
         c = *lex.cursor;
         if (c == closer) {
             lex.set_token(SYMBOL_IDENTIFIER, start, parse_position_t(lex.cursor));
-            return true;
+            return TOKEN_FOUND;
         }
     }
     // We will get here if there was a start of a delimited escape sequence but we
     // never found the closing escape character(s). Set the parse context's
     // error to indicate the location that an error occurred.
-    std::stringstream estr;
-    estr << "In delimited identifier parsing, failed to find closing escape character ";
-    if (closer == '\'') {
-        estr << "\"\'\".\n";
-    } else {
-        estr << "\'" << closer << "\'.\n";
-    }
-    create_syntax_error_marker(ctx, estr, start);
-    ctx.result.error.assign(estr.str());
-    lex.error = ERR_NO_CLOSING_DELIMITER;
-    return false;
+    return TOKEN_ERR_NO_CLOSING_DELIMITER;
 }
 
 } // namespace sqltoast

--- a/src/parser/identifier.cc
+++ b/src/parser/identifier.cc
@@ -4,17 +4,7 @@
  * See the COPYING file in the root project directory for full text.
  */
 
-#include <sstream>
-#include <string>
-
-#include <stdio.h>
-#include <stdlib.h>
-
-#include "context.h"
-#include "error.h"
-#include "identifier.h"
-#include "symbol.h"
-#include "token.h"
+#include "parser/identifier.h"
 
 namespace sqltoast {
 
@@ -34,8 +24,7 @@ namespace sqltoast {
 //
 // Note that whitespace will have been skipped already so that the character
 // pointed to by the parse context is guaranteed to be not whitespace.
-tokenize_result_t token_identifier(parse_context_t& ctx) {
-    lexer_t& lex = ctx.lexer;
+tokenize_result_t token_identifier(lexer_t& lex) {
     parse_position_t start = lex.cursor;
     escape_mode current_escape = ESCAPE_NONE;
 
@@ -61,7 +50,7 @@ tokenize_result_t token_identifier(parse_context_t& ctx) {
     }
     if (current_escape != ESCAPE_NONE)
         // handle delimited identifiers...
-        return token_delimited_identifier(ctx, current_escape);
+        return token_delimited_identifier(lex, current_escape);
 
     // If we're not a delimited identifier, then consume all non-space characters
     // until the end of the parse subject or the next whitespace character
@@ -82,8 +71,7 @@ tokenize_result_t token_identifier(parse_context_t& ctx) {
     return res;
 }
 
-tokenize_result_t token_delimited_identifier(parse_context_t& ctx, escape_mode current_escape) {
-    lexer_t& lex = ctx.lexer;
+tokenize_result_t token_delimited_identifier(lexer_t& lex, escape_mode current_escape) {
     parse_position_t start = lex.cursor;
     char closer;
     switch (current_escape) {

--- a/src/parser/identifier.h
+++ b/src/parser/identifier.h
@@ -7,19 +7,17 @@
 #ifndef SQLTOAST_IDENTIFIER_H
 #define SQLTOAST_IDENTIFIER_H
 
-#include <string>
-
-#include "context.h"
+#include "parser/lexer.h"
 
 namespace sqltoast {
 
 // Returns true if an identifier (of any kind) can be parsed from the parse
 // context's cursor position
-tokenize_result_t token_identifier(parse_context_t& ctx);
+tokenize_result_t token_identifier(lexer_t& lex);
 
 // Returns true if a delimited identifier can be parsed from the parse
 // context's cursor position.
-tokenize_result_t token_delimited_identifier(parse_context_t& ctx, escape_mode current_escape);
+tokenize_result_t token_delimited_identifier(lexer_t& lex, escape_mode current_escape);
 
 } // namespace sqltoast
 

--- a/src/parser/identifier.h
+++ b/src/parser/identifier.h
@@ -15,11 +15,11 @@ namespace sqltoast {
 
 // Returns true if an identifier (of any kind) can be parsed from the parse
 // context's cursor position
-bool token_identifier(parse_context_t& ctx);
+tokenize_result_t token_identifier(parse_context_t& ctx);
 
 // Returns true if a delimited identifier can be parsed from the parse
 // context's cursor position.
-bool token_delimited_identifier(parse_context_t& ctx, escape_mode current_escape);
+tokenize_result_t token_delimited_identifier(parse_context_t& ctx, escape_mode current_escape);
 
 } // namespace sqltoast
 

--- a/src/parser/keyword.cc
+++ b/src/parser/keyword.cc
@@ -63,7 +63,7 @@ kw_jump_table_t kw_jump_tables::s = _init_kw_jump_table('s');
 kw_jump_table_t kw_jump_tables::t = _init_kw_jump_table('t');
 kw_jump_table_t kw_jump_tables::v = _init_kw_jump_table('v');
 
-bool token_keyword(parse_context_t& ctx) {
+tokenize_result_t token_keyword(parse_context_t& ctx) {
     lexer_t& lex = ctx.lexer;
     kw_jump_table_t* jump_tbl;
     switch (*lex.cursor) {
@@ -104,7 +104,7 @@ bool token_keyword(parse_context_t& ctx) {
             jump_tbl = &kw_jump_tables::v;
             break;
         default:
-            return false;
+            return TOKEN_NOT_FOUND;
     }
 
     parse_position_t start = lex.cursor;
@@ -124,10 +124,10 @@ bool token_keyword(parse_context_t& ctx) {
         if (ci_find_substr(lexeme, entry.kw_str) == 0) {
             lex.set_token(entry.symbol, start, end);
             lex.cursor += entry_len;
-            return true;
+            return TOKEN_FOUND;
         }
     }
-    return false;
+    return TOKEN_NOT_FOUND;
 }
 
 } // namespace sqltoast

--- a/src/parser/keyword.cc
+++ b/src/parser/keyword.cc
@@ -4,10 +4,8 @@
  * See the COPYING file in the root project directory for full text.
  */
 
-#include "compare.h"
-#include "keyword.h"
-#include "token.h"
-#include "symbol.h"
+#include "parser/compare.h"
+#include "parser/keyword.h"
 
 namespace sqltoast {
 
@@ -63,8 +61,7 @@ kw_jump_table_t kw_jump_tables::s = _init_kw_jump_table('s');
 kw_jump_table_t kw_jump_tables::t = _init_kw_jump_table('t');
 kw_jump_table_t kw_jump_tables::v = _init_kw_jump_table('v');
 
-tokenize_result_t token_keyword(parse_context_t& ctx) {
-    lexer_t& lex = ctx.lexer;
+tokenize_result_t token_keyword(lexer_t& lex) {
     kw_jump_table_t* jump_tbl;
     switch (*lex.cursor) {
         case 'a':

--- a/src/parser/keyword.h
+++ b/src/parser/keyword.h
@@ -62,7 +62,7 @@ kw_jump_table_t _init_kw_jump_table(char c);
 // Moves the supplied parse context's cursor to the next keyword found in the
 // context's input stream and sets the context's current symbol to the found
 // keyword symbol. Returns whether a keyword was found.
-bool token_keyword(parse_context_t& ctx);
+tokenize_result_t token_keyword(parse_context_t& ctx);
 
 } // namespace sqltoast
 

--- a/src/parser/keyword.h
+++ b/src/parser/keyword.h
@@ -10,8 +10,7 @@
 #include <vector>
 #include <string>
 
-#include "context.h"
-#include "symbol.h"
+#include "parser/lexer.h"
 
 namespace sqltoast {
 
@@ -62,7 +61,7 @@ kw_jump_table_t _init_kw_jump_table(char c);
 // Moves the supplied parse context's cursor to the next keyword found in the
 // context's input stream and sets the context's current symbol to the found
 // keyword symbol. Returns whether a keyword was found.
-tokenize_result_t token_keyword(parse_context_t& ctx);
+tokenize_result_t token_keyword(lexer_t& lex);
 
 } // namespace sqltoast
 

--- a/src/parser/lexer.cc
+++ b/src/parser/lexer.cc
@@ -41,7 +41,10 @@ void lexer_t::skip_simple_comments() {
 
 token_t* next_token(parse_context_t &ctx) {
     lexer_t& lex = ctx.lexer;
-    lex.skip();
+    // Advance the lexer's cursor over any whitespace or simple comments
+    while (std::isspace(*lex.cursor))
+        lex.cursor++;
+    lex.skip_simple_comments();
     if (token_comment(ctx))
         return &lex.current_token;
     if (lex.error != ERR_NONE)

--- a/src/parser/lexer.cc
+++ b/src/parser/lexer.cc
@@ -43,23 +43,22 @@ static size_t NUM_TOKENIZERS = 5;
 static tokenize_func_t tokenizers[5] = {
     &token_comment,
     &token_punctuator,
-    &token_literal,
     &token_keyword,
+    &token_literal,
     &token_identifier
 };
 
-token_t* next_token(parse_context_t &ctx) {
-    lexer_t& lex = ctx.lexer;
+token_t* lexer_t::next_token() {
     // Advance the lexer's cursor over any whitespace or simple comments
-    while (std::isspace(*lex.cursor))
-        lex.cursor++;
-    lex.skip_simple_comments();
+    while (std::isspace(*cursor))
+        cursor++;
+    skip_simple_comments();
 
     tokenize_result_t tok_res;
     for (size_t x = 0; x < NUM_TOKENIZERS; x++) {
-        tok_res = tokenizers[x](ctx);
+        tok_res = tokenizers[x](*this);
         if (tok_res == TOKEN_FOUND)
-            return &lex.current_token;
+            return &current_token;
         if (tok_res == TOKEN_NOT_FOUND)
             continue;
         // There was an error in tokenizing

--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -38,14 +38,6 @@ typedef struct lexer {
         current_token(SYMBOL_SOS, subject.cbegin(), subject.cbegin())
     {}
     void skip_simple_comments();
-    // Simply advances the lexer's cursor over any whitespace or simple
-    // comments
-    inline void skip() {
-        while (std::isspace(*cursor))
-            cursor++;
-        skip_simple_comments();
-        return;
-    }
     inline bool peek_char(const char c) {
         return ((cursor != end_pos && (*cursor == c)));
     }

--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -50,7 +50,19 @@ typedef struct lexer {
 #endif
         return;
     }
+
+    // Attempts to find the next token. If a token was found, returns a pointer
+    // to that token, else NULL.
+    token_t* next_token();
 } lexer_t;
+
+typedef enum tokenize_result {
+    TOKEN_FOUND,
+    TOKEN_NOT_FOUND,
+    TOKEN_ERR_NO_CLOSING_DELIMITER
+} tokenize_result_t;
+
+typedef tokenize_result_t (*tokenize_func_t) (lexer_t& lex);
 
 void fill_lexeme(token_t* tok, lexeme_t& lexeme);
 

--- a/src/parser/literal.cc
+++ b/src/parser/literal.cc
@@ -8,8 +8,7 @@
 
 namespace sqltoast {
 
-tokenize_result_t token_literal(parse_context_t& ctx) {
-    lexer_t& lex = ctx.lexer;
+tokenize_result_t token_literal(lexer_t& lex) {
     parse_cursor_t start = lex.cursor;
     symbol_t found_sym;
     bool found_sign = false; // set to true if + or - found

--- a/src/parser/literal.cc
+++ b/src/parser/literal.cc
@@ -4,12 +4,11 @@
  * See the COPYING file in the root project directory for full text.
  */
 
-#include "literal.h"
-#include "token.h"
+#include "parser/literal.h"
 
 namespace sqltoast {
 
-bool token_literal(parse_context_t& ctx) {
+tokenize_result_t token_literal(parse_context_t& ctx) {
     lexer_t& lex = ctx.lexer;
     parse_cursor_t start = lex.cursor;
     symbol_t found_sym;
@@ -119,10 +118,10 @@ push_literal:
         found_sym,
         parse_position_t(start),
         parse_position_t(lex.cursor));
-    return true;
+    return TOKEN_FOUND;
 not_found:
     lex.cursor = start; // rewind... we didn't find a literal
-    return false;
+    return TOKEN_NOT_FOUND;
 }
 
 } // namespace sqltoast

--- a/src/parser/literal.h
+++ b/src/parser/literal.h
@@ -7,15 +7,14 @@
 #ifndef SQLTOAST_PARSER_LITERAL_H
 #define SQLTOAST_PARSER_LITERAL_H
 
-#include "parser/context.h"
-#include "parser/token.h"
+#include "parser/lexer.h"
 
 namespace sqltoast {
 
 // Moves the supplied parse context's cursor to the next literal found in the
 // context's input stream and adds a token with type literal to the tokens
 // stack.Returns whether a literal was found.
-tokenize_result_t token_literal(parse_context_t& ctx);
+tokenize_result_t token_literal(lexer_t& lex);
 
 } // namespace sqltoast
 

--- a/src/parser/literal.h
+++ b/src/parser/literal.h
@@ -7,14 +7,15 @@
 #ifndef SQLTOAST_PARSER_LITERAL_H
 #define SQLTOAST_PARSER_LITERAL_H
 
-#include "context.h"
+#include "parser/context.h"
+#include "parser/token.h"
 
 namespace sqltoast {
 
 // Moves the supplied parse context's cursor to the next literal found in the
 // context's input stream and adds a token with type literal to the tokens
 // stack.Returns whether a literal was found.
-bool token_literal(parse_context_t& ctx);
+tokenize_result_t token_literal(parse_context_t& ctx);
 
 } // namespace sqltoast
 

--- a/src/parser/parse.cc
+++ b/src/parser/parse.cc
@@ -38,7 +38,7 @@ parse_result_t parse(parse_input_t& subject, parse_options_t& opts) {
     }
 
     while (res.code == PARSE_OK) {
-        cur_tok = next_token(ctx);
+        cur_tok = lex.next_token();
         if (cur_tok == NULL)
             return res;
         if (cur_tok->is_keyword()) {

--- a/src/parser/punctuator.cc
+++ b/src/parser/punctuator.cc
@@ -4,12 +4,11 @@
  * See the COPYING file in the root project directory for full text.
  */
 
-#include "punctuator.h"
-#include "token.h"
+#include "parser/punctuator.h"
 
 namespace sqltoast {
 
-bool token_punctuator(parse_context_t& ctx) {
+tokenize_result_t token_punctuator(parse_context_t& ctx) {
     lexer_t& lex = ctx.lexer;
     const char c = *lex.cursor++;
     for (unsigned int x = 0; x < NUM_PUNCTUATORS; x++) {
@@ -19,11 +18,11 @@ bool token_punctuator(parse_context_t& ctx) {
                 parse_position_t(lex.cursor),
                 parse_position_t(lex.cursor+1)
             );
-            return true;
+            return TOKEN_FOUND;
         }
     }
     lex.cursor--; // rewind... we didn't find a punctuator
-    return false;
+    return TOKEN_NOT_FOUND;
 }
 
 } // namespace sqltoast

--- a/src/parser/punctuator.cc
+++ b/src/parser/punctuator.cc
@@ -8,8 +8,7 @@
 
 namespace sqltoast {
 
-tokenize_result_t token_punctuator(parse_context_t& ctx) {
-    lexer_t& lex = ctx.lexer;
+tokenize_result_t token_punctuator(lexer_t& lex) {
     const char c = *lex.cursor++;
     for (unsigned int x = 0; x < NUM_PUNCTUATORS; x++) {
         if (c == punctuator_char_map[x]) {

--- a/src/parser/punctuator.h
+++ b/src/parser/punctuator.h
@@ -7,17 +7,11 @@
 #ifndef SQLTOAST_PARSER_PUNCTUATOR_H
 #define SQLTOAST_PARSER_PUNCTUATOR_H
 
-#include "context.h"
-#include "symbol.h"
+#include "parser/context.h"
+#include "parser/symbol.h"
+#include "parser/token.h"
 
 namespace sqltoast {
-
-typedef enum punctuator {
-    PUNCTUATOR_SEMICOLON,
-    PUNCTUATOR_COMMA,
-    PUNCTUATOR_LPAREN,
-    PUNCTUATOR_RPAREN,
-} punctuator_t;
 
 const unsigned int NUM_PUNCTUATORS = 4;
 
@@ -38,7 +32,7 @@ static const symbol_t punctuator_symbol_map[4] = {
 // Moves the supplied parse context's cursor to the next punctuator found in the
 // context's input stream and sets the context's current symbol to the found
 // punctuator symbol. Returns whether a punctuator was found.
-bool token_punctuator(parse_context_t& ctx);
+tokenize_result_t token_punctuator(parse_context_t& ctx);
 
 } // namespace sqltoast
 

--- a/src/parser/punctuator.h
+++ b/src/parser/punctuator.h
@@ -7,9 +7,8 @@
 #ifndef SQLTOAST_PARSER_PUNCTUATOR_H
 #define SQLTOAST_PARSER_PUNCTUATOR_H
 
-#include "parser/context.h"
+#include "parser/lexer.h"
 #include "parser/symbol.h"
-#include "parser/token.h"
 
 namespace sqltoast {
 
@@ -32,7 +31,7 @@ static const symbol_t punctuator_symbol_map[4] = {
 // Moves the supplied parse context's cursor to the next punctuator found in the
 // context's input stream and sets the context's current symbol to the found
 // punctuator symbol. Returns whether a punctuator was found.
-tokenize_result_t token_punctuator(parse_context_t& ctx);
+tokenize_result_t token_punctuator(lexer_t& lex);
 
 } // namespace sqltoast
 

--- a/src/parser/sequence.h
+++ b/src/parser/sequence.h
@@ -21,7 +21,7 @@ inline bool follows_sequence(parse_context_t& ctx, const symbol_t expected_seque
     token_t* cur_tok;
     for (unsigned int x = 0; x < num_expected; x++) {
         exp_sym = expected_sequence[x];
-        cur_tok = next_token(ctx);
+        cur_tok = ctx.lexer.next_token();
         if (cur_tok == NULL)
             goto err_unexpected;
         cur_sym = (*cur_tok).symbol;

--- a/src/parser/statements/create_schema.cc
+++ b/src/parser/statements/create_schema.cc
@@ -66,6 +66,7 @@ bool require_default_charset_clause(parse_context_t& ctx) {
 }
 
 bool parse_create_schema(parse_context_t& ctx) {
+    lexer_t& lex = ctx.lexer;
     parse_cursor_t start = ctx.lexer.cursor;
     token_t* cur_tok;
     lexeme_t ident;
@@ -77,7 +78,7 @@ bool parse_create_schema(parse_context_t& ctx) {
 
     // BEGIN STATE MACHINE
 
-    cur_tok = next_token(ctx);
+    cur_tok = lex.next_token();
     if (cur_tok == NULL)
         return false;
     cur_sym = cur_tok->symbol;
@@ -94,11 +95,11 @@ bool parse_create_schema(parse_context_t& ctx) {
         // We get here after successfully finding CREATE followed by SCHEMA. We
         // now need to find either an identifier or the schema authorization
         // clause
-        cur_tok = next_token(ctx);
+        cur_tok = lex.next_token();
         cur_sym = cur_tok->symbol;
         if (cur_sym == SYMBOL_IDENTIFIER) {
             fill_lexeme(cur_tok, ident);
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto authz_or_statement_ending;
         }
         goto authorization_clause;
@@ -107,7 +108,7 @@ bool parse_create_schema(parse_context_t& ctx) {
         if (require_default_charset_clause(ctx)) {
             found_default_charset = true;
             fill_lexeme(cur_tok, default_charset_ident);
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto statement_ending;
         }
         return false;
@@ -119,7 +120,7 @@ bool parse_create_schema(parse_context_t& ctx) {
         if (cur_sym == SYMBOL_IDENTIFIER) {
             found_authz = true;
             fill_lexeme(cur_tok, authz_ident);
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto default_charset_or_statement_ending;
         }
         goto err_expect_authz_identifier;
@@ -164,10 +165,10 @@ bool parse_create_schema(parse_context_t& ctx) {
         cur_sym = cur_tok->symbol;
         if (cur_sym == SYMBOL_SEMICOLON) {
             // skip-consume the semicolon token
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto push_statement;
         } else if (cur_sym == SYMBOL_AUTHORIZATION) {
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto authorization_clause;
         } else if (cur_sym == SYMBOL_DEFAULT) {
             goto default_charset_clause;
@@ -193,7 +194,7 @@ bool parse_create_schema(parse_context_t& ctx) {
         cur_sym = cur_tok->symbol;
         if (cur_sym == SYMBOL_SEMICOLON) {
             // skip-consume the semicolon token
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto push_statement;
         }
         {

--- a/src/parser/statements/create_table.cc
+++ b/src/parser/statements/create_table.cc
@@ -38,24 +38,24 @@ bool parse_create_table(parse_context_t& ctx) {
     std::vector<std::unique_ptr<column_definition_t>> column_defs;
 
     // BEGIN STATE MACHINE
-    start:
-        cur_tok = next_token(ctx);
-        if (cur_tok == NULL)
+
+    cur_tok = next_token(ctx);
+    if (cur_tok == NULL)
+        return false;
+    cur_sym = cur_tok->symbol;
+    switch (cur_sym) {
+        case SYMBOL_TABLE:
+            goto expect_table_name;
+        case SYMBOL_GLOBAL:
+        case SYMBOL_LOCAL:
+        case SYMBOL_TEMPORARY:
+            goto table_kw_or_table_type;
+        default:
+            // rewind
+            ctx.lexer.cursor = start;
             return false;
-        cur_sym = cur_tok->symbol;
-        switch (cur_sym) {
-            case SYMBOL_TABLE:
-                goto expect_table_name;
-            case SYMBOL_GLOBAL:
-            case SYMBOL_LOCAL:
-            case SYMBOL_TEMPORARY:
-                goto table_kw_or_table_type;
-            default:
-                // rewind
-                ctx.lexer.cursor = start;
-                return false;
-        }
-        SQLTOAST_UNREACHABLE();
+    }
+
     table_kw_or_table_type:
         // We get here after successfully finding the CREATE symbol. We can
         // either match the table keyword or the table type clause

--- a/src/parser/statements/create_table.cc
+++ b/src/parser/statements/create_table.cc
@@ -30,6 +30,7 @@ namespace sqltoast {
 //
 
 bool parse_create_table(parse_context_t& ctx) {
+    lexer_t& lex = ctx.lexer;
     parse_cursor_t start = ctx.lexer.cursor;
     token_t* cur_tok;
     lexeme_t ident;
@@ -39,7 +40,7 @@ bool parse_create_table(parse_context_t& ctx) {
 
     // BEGIN STATE MACHINE
 
-    cur_tok = next_token(ctx);
+    cur_tok = lex.next_token();
     if (cur_tok == NULL)
         return false;
     cur_sym = cur_tok->symbol;
@@ -74,7 +75,7 @@ bool parse_create_table(parse_context_t& ctx) {
         // We get here if we successfully matched CREATE followed by either the
         // GLOBAL or LOCAL symbol. If this is the case, we expect to find the
         // TEMPORARY keyword followed by the TABLE keyword.
-        cur_tok = next_token(ctx);
+        cur_tok = lex.next_token();
         if (cur_tok == NULL)
             goto err_expect_temporary;
         cur_sym = cur_tok->symbol;
@@ -98,7 +99,7 @@ bool parse_create_table(parse_context_t& ctx) {
         }
         SQLTOAST_UNREACHABLE();
     expect_table:
-        cur_tok = next_token(ctx);
+        cur_tok = lex.next_token();
         if (cur_tok == NULL)
             goto err_expect_table;
         cur_sym = cur_tok->symbol;
@@ -126,7 +127,7 @@ bool parse_create_table(parse_context_t& ctx) {
         // We get here after successfully finding CREATE followed by the TABLE
         // symbol (after optionally processing the table type modifier). We now
         // need to find an identifier
-        cur_tok = next_token(ctx);
+        cur_tok = lex.next_token();
         if (cur_tok == NULL)
             goto err_expect_identifier;
         cur_sym = cur_tok->symbol;
@@ -156,7 +157,7 @@ bool parse_create_table(parse_context_t& ctx) {
         // We get here after successfully finding the CREATE ... TABLE <table name>
         // part of the statement. We now expect to find the <table element
         // list> clause
-        cur_tok = next_token(ctx);
+        cur_tok = lex.next_token();
         if (cur_tok == NULL)
             goto err_expect_lparen;
         cur_sym = cur_tok->symbol;
@@ -185,7 +186,7 @@ bool parse_create_table(parse_context_t& ctx) {
         // We get here after finding the LPAREN opening the <table element
         // list> clause. Now we expect to find one or more column or constraint
         // definitions
-        cur_tok = next_token(ctx);
+        cur_tok = lex.next_token();
         if (cur_tok == NULL)
             goto err_expect_column_definition;
         if (! parse_column_definition(ctx, cur_tok, column_defs))
@@ -209,7 +210,7 @@ bool parse_create_table(parse_context_t& ctx) {
             goto err_expect_rparen;
         cur_sym = cur_tok->symbol;
         if (cur_sym == SYMBOL_RPAREN) {
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto statement_ending;
         }
         goto err_expect_rparen;
@@ -241,7 +242,7 @@ bool parse_create_table(parse_context_t& ctx) {
         cur_sym = cur_tok->symbol;
         if (cur_sym == SYMBOL_SEMICOLON) {
             // skip-consume the semicolon token
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto push_statement;
         }
         {

--- a/src/parser/statements/drop_schema.cc
+++ b/src/parser/statements/drop_schema.cc
@@ -32,6 +32,7 @@ namespace sqltoast {
 //
 
 bool parse_drop_schema(parse_context_t& ctx) {
+    lexer_t& lex = ctx.lexer;
     parse_cursor_t start = ctx.lexer.cursor;
     lexeme_t ident;
     token_t* cur_tok;
@@ -40,13 +41,13 @@ bool parse_drop_schema(parse_context_t& ctx) {
 
     // BEGIN STATE MACHINE
 
-    cur_tok = next_token(ctx);
+    cur_tok = lex.next_token();
     if (cur_tok == NULL)
         return false;
     cur_sym = cur_tok->symbol;
     switch (cur_sym) {
         case SYMBOL_SCHEMA:
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto expect_identifier;
         default:
             // rewind
@@ -62,7 +63,7 @@ bool parse_drop_schema(parse_context_t& ctx) {
         cur_sym = cur_tok->symbol;
         if (cur_sym == SYMBOL_IDENTIFIER) {
             fill_lexeme(cur_tok, ident);
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto drop_behaviour_or_statement_ending;
         }
         goto err_expect_identifier;
@@ -95,7 +96,7 @@ bool parse_drop_schema(parse_context_t& ctx) {
             if (cur_sym == SYMBOL_RESTRICT) {
                 behaviour = statements::DROP_BEHAVIOUR_RESTRICT;
             }
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
         }
         goto statement_ending;
     statement_ending:
@@ -108,7 +109,7 @@ bool parse_drop_schema(parse_context_t& ctx) {
         cur_sym = cur_tok->symbol;
         if (cur_sym == SYMBOL_SEMICOLON) {
             // skip-consume the semicolon token
-            cur_tok = next_token(ctx);
+            cur_tok = lex.next_token();
             goto push_statement;
         }
         {

--- a/src/parser/statements/drop_schema.cc
+++ b/src/parser/statements/drop_schema.cc
@@ -40,21 +40,20 @@ bool parse_drop_schema(parse_context_t& ctx) {
 
     // BEGIN STATE MACHINE
 
-    start:
-        cur_tok = next_token(ctx);
-        if (cur_tok == NULL)
+    cur_tok = next_token(ctx);
+    if (cur_tok == NULL)
+        return false;
+    cur_sym = cur_tok->symbol;
+    switch (cur_sym) {
+        case SYMBOL_SCHEMA:
+            cur_tok = next_token(ctx);
+            goto expect_identifier;
+        default:
+            // rewind
+            ctx.lexer.cursor = start;
             return false;
-        cur_sym = cur_tok->symbol;
-        switch (cur_sym) {
-            case SYMBOL_SCHEMA:
-                cur_tok = next_token(ctx);
-                goto expect_identifier;
-            default:
-                // rewind
-                ctx.lexer.cursor = start;
-                return false;
-        }
-        SQLTOAST_UNREACHABLE();
+    }
+
     expect_identifier:
         // We get here after successfully finding DROP followed by SCHEMA. We
         // now need to find the schema identifier


### PR DESCRIPTION
Does the work of encapsulating tokenization entirely within the lexer_t struct.

Issue #15