### PR TITLE
major overhaul of how tokens are processed

### DIFF
--- a/src/parser/column_definition.cc
+++ b/src/parser/column_definition.cc
@@ -32,10 +32,10 @@ namespace sqltoast {
 
 bool parse_column_definition(
         parse_context_t& ctx,
-        token_t* cur_tok,
+        token_t& cur_tok,
         std::vector<std::unique_ptr<column_definition_t>>& column_defs) {
     lexeme_t ident;
-    symbol_t cur_sym = cur_tok->symbol;
+    symbol_t cur_sym = cur_tok.symbol;
     std::unique_ptr<column_definition_t> cdef_p;
 
     // BEGIN STATE MACHINE

--- a/src/parser/comment.cc
+++ b/src/parser/comment.cc
@@ -44,7 +44,7 @@ tokenize_result_t token_comment(parse_position_t cursor) {
     do {
         cursor++;
         if (*cursor == '\0' || *(cursor + 1) == '\0') {
-            return tokenize_result_t(TOKEN_ERR_NO_CLOSING_DELIMITER);
+            return tokenize_result_t(TOKEN_ERR_NO_CLOSING_DELIMITER, start, cursor);
         }
     } while (*cursor != '*' || *(cursor + 1) != '/');
     return tokenize_result_t(SYMBOL_COMMENT, start, cursor + 1);

--- a/src/parser/data_type_descriptor.cc
+++ b/src/parser/data_type_descriptor.cc
@@ -12,7 +12,7 @@
 
 #include "parser/parse.h"
 #include "parser/error.h"
-#include "parser/token.h"
+#include "parser/sequence.h"
 
 namespace sqltoast {
 
@@ -122,9 +122,9 @@ namespace sqltoast {
 
 bool parse_data_type_descriptor(
         parse_context_t& ctx,
-        token_t* cur_tok,
+        token_t& cur_tok,
         column_definition_t& column_def) {
-    symbol_t cur_sym = cur_tok->symbol;
+    symbol_t cur_sym = cur_tok.symbol;
 
     // BEGIN STATE MACHINE
 
@@ -134,7 +134,9 @@ bool parse_data_type_descriptor(
         case SYMBOL_CHAR:
         case SYMBOL_CHARACTER:
         case SYMBOL_VARCHAR:
-            return parse_character_string(ctx, cur_tok, column_def);
+            if (! parse_character_string(ctx, cur_tok, column_def))
+                return false;
+            goto optional_character_set;
         default:
             goto err_expect_data_type;
     }
@@ -142,25 +144,58 @@ err_expect_data_type:
     {
         parse_position_t err_pos = ctx.lexer.cursor;
         std::stringstream estr;
-        if (cur_tok == NULL) {
-            estr << "Expected data type after <column name> but found EOS";
-        } else {
-            cur_sym = cur_tok->symbol;
-            estr << "Expected data type after <column name> but found "
-                 << symbol_map::to_string(cur_sym);
-        }
+        estr << "Expected data type after <column name> but found "
+             << symbol_map::to_string(cur_sym);
         estr << std::endl;
         create_syntax_error_marker(ctx, estr, err_pos);
         return false;
     }
+optional_character_set:
+    // We get here after processing the optional length specifier. After
+    // that specifier, there may be an optional CHARACTER SET <character
+    // set specification> clause
+    {
+        symbol_t cur_sym = ctx.lexer.current_token.symbol;
+        if (cur_sym == SYMBOL_EOS ||
+                cur_sym == SYMBOL_COMMA ||
+                cur_sym == SYMBOL_RPAREN)
+            return true;
+        if (cur_sym == SYMBOL_CHARACTER) {
+            goto process_character_set;
+        }
+    }
+    return true;
+process_character_set:
+    {
+        symbol_t exp_sym_seq[3] = {
+            SYMBOL_CHARACTER,
+            SYMBOL_SET,
+            SYMBOL_IDENTIFIER
+        };
+        if (! expect_sequence(ctx, exp_sym_seq, 3)) {
+            return false;
+        }
+        // tack the character set onto the char_string_t data type descriptor
+        char_string_t* dtd = static_cast<char_string_t*>(column_def.data_type.get());
+        return true;
+    }
 }
 
+//
+// <character string type> ::=
+//     CHARACTER [ <left paren> <length> <right paren> ]
+//     | CHAR [ <left paren> <length> <right paren> ]
+//     | CHARACTER VARYING [ <left paren> <length> <right paren> ]
+//     | CHAR VARYING [ <left paren> <length> <right paren> ]
+//     | VARCHAR [ <left paren> <length> <right paren> ]
+//
+// <length> ::= <unsigned integer>
 bool parse_character_string(
         parse_context_t& ctx,
-        token_t* cur_tok,
+        token_t& cur_tok,
         column_definition_t& column_def) {
     lexer_t& lex = ctx.lexer;
-    symbol_t cur_sym = cur_tok->symbol;
+    symbol_t cur_sym = cur_tok.symbol;
     data_type_t data_type = DATA_TYPE_CHAR;
     size_t char_len = 0;
 
@@ -186,9 +221,7 @@ optional_char_varying:
     // We get here if we got a CHAR or CHARACTER as the data type. This
     // might be followed by the VARYING symbol, in which case we will
     // process a VARCHAR. Otherwise, we'll process a CHAR type
-    if (cur_tok == NULL)
-        goto push_descriptor;
-    cur_sym = cur_tok->symbol;
+    cur_sym = cur_tok.symbol;
     if (cur_sym == SYMBOL_VARYING) {
         data_type = DATA_TYPE_VARCHAR;
         cur_tok = lex.next();
@@ -198,43 +231,33 @@ optional_length:
     // We get here after determining the exact type of the character
     // string. The type will be followed by an optional length specifier
     // clause, which if an unsigned integer enclosed by parentheses.
-    if (cur_tok == NULL)
-        goto push_descriptor;
-    cur_sym = cur_tok->symbol;
+    cur_sym = cur_tok.symbol;
     if (cur_sym == SYMBOL_LPAREN) {
         cur_tok = lex.next();
         goto process_length;
     }
-    goto optional_character_set;
+    goto push_descriptor;
 process_length:
     // We get here if we've processed the opening parentheses of the
     // optional length modifier and now expect to find an unsigned integer
     // followed by a closing parentheses
-    if (cur_tok == NULL)
-        goto err_expect_size_literal;
-    if (cur_tok->is_literal()) {
+    if (cur_tok.is_literal()) {
         // Make sure we can parse our literal token to an unsigned integer
-        cur_sym = cur_tok->symbol;
+        cur_sym = cur_tok.symbol;
         if (cur_sym != SYMBOL_LITERAL_UNSIGNED_INTEGER)
             goto err_expect_size_literal;
-        const std::string char_len_str(cur_tok->lexeme.start, cur_tok->lexeme.end);
+        const std::string char_len_str(cur_tok.lexeme.start, cur_tok.lexeme.end);
         char_len = atoi(char_len_str.data());
         cur_tok = lex.next();
         goto length_close;
-    } else {
-        goto err_expect_size_literal;
     }
+    goto err_expect_size_literal;
 err_expect_size_literal:
     {
         parse_position_t err_pos = ctx.lexer.cursor;
         std::stringstream estr;
-        if (cur_tok == NULL) {
-            estr << "Expected unsigned integer as length after '(' but found EOS";
-        } else {
-            cur_sym = cur_tok->symbol;
-            estr << "Expected unsigned integer as length after '(' but found "
-                 << symbol_map::to_string(cur_sym);
-        }
+        estr << "Expected unsigned integer as length after '(' but found "
+             << symbol_map::to_string(cur_sym);
         estr << std::endl;
         create_syntax_error_marker(ctx, estr, err_pos);
         return false;
@@ -243,48 +266,21 @@ length_close:
     // We get here if we've processed the opening parentheses of the length
     // modifier and the unsigned integer size and now expect a closing
     // parentheses for the length modifier
-    if (cur_tok == NULL)
-        goto err_expect_length_rparen;
-    cur_sym = cur_tok->symbol;
+    cur_sym = cur_tok.symbol;
     if (cur_sym == SYMBOL_RPAREN) {
-        goto optional_character_set;
+        goto push_descriptor;
     }
     goto err_expect_length_rparen;
 err_expect_length_rparen:
     {
         parse_position_t err_pos = ctx.lexer.cursor;
         std::stringstream estr;
-        if (cur_tok == NULL) {
-            estr << "Expected ')' after length specifier but found EOS";
-        } else {
-            cur_sym = cur_tok->symbol;
-            estr << "Expected ')' after length specifier but found "
-                 << symbol_map::to_string(cur_sym);
-        }
+        estr << "Expected ')' after length specifier but found "
+             << symbol_map::to_string(cur_sym);
         estr << std::endl;
         create_syntax_error_marker(ctx, estr, err_pos);
         return false;
     }
-optional_character_set:
-    // We get here after processing the optional length specifier. After
-    // that specifier, there may be an optional CHARACTER SET <character
-    // set specification> clause
-    {
-        symbol_t peek_sym = lex.peek();
-        if (peek_sym == SYMBOL_EOS)
-            goto push_descriptor;
-        if (peek_sym == SYMBOL_COMMA)
-            goto push_descriptor;
-        if (peek_sym == SYMBOL_RPAREN)
-            goto push_descriptor;
-        if (peek_sym == SYMBOL_CHARACTER) {
-            cur_tok = lex.next();
-            goto process_character_set;
-        }
-    }
-    goto push_descriptor;
-process_character_set:
-    goto push_descriptor;
 push_descriptor:
     {
         if (ctx.opts.disable_statement_construction)

--- a/src/parser/identifier.cc
+++ b/src/parser/identifier.cc
@@ -65,7 +65,7 @@ tokenize_result_t token_identifier(parse_position_t cursor) {
     // if we went more than a single character, that's an
     // identifier...
     if (start != cursor)
-        return tokenize_result_t(SYMBOL_IDENTIFIER, start, parse_position_t(cursor));
+        return tokenize_result_t(SYMBOL_IDENTIFIER, start, cursor);
     return tokenize_result_t(TOKEN_NOT_FOUND);
 }
 
@@ -91,13 +91,13 @@ tokenize_result_t token_delimited_identifier(parse_position_t cursor, escape_mod
         cursor++;
         c = *cursor;
         if (c == closer) {
-            return tokenize_result_t(SYMBOL_IDENTIFIER, start, parse_position_t(cursor));
+            return tokenize_result_t(SYMBOL_IDENTIFIER, start, cursor);
         }
     }
     // We will get here if there was a start of a delimited escape sequence but we
     // never found the closing escape character(s). Set the parse context's
     // error to indicate the location that an error occurred.
-    return tokenize_result_t(TOKEN_ERR_NO_CLOSING_DELIMITER);
+    return tokenize_result_t(TOKEN_ERR_NO_CLOSING_DELIMITER, start, cursor);
 }
 
 } // namespace sqltoast

--- a/src/parser/keyword.cc
+++ b/src/parser/keyword.cc
@@ -117,7 +117,7 @@ tokenize_result_t token_keyword(parse_position_t cursor) {
         if (lexeme_len != entry_len)
             continue;
         if (ci_find_substr(lexeme, entry.kw_str) == 0) {
-            return tokenize_result_t(entry.symbol, start, start + entry_len - 1);
+            return tokenize_result_t(entry.symbol, start, start + entry_len);
         }
     }
     return tokenize_result_t(TOKEN_NOT_FOUND);

--- a/src/parser/literal.cc
+++ b/src/parser/literal.cc
@@ -112,10 +112,7 @@ try_numeric:
         }
     }
 push_literal:
-    return tokenize_result_t(
-        found_sym,
-        parse_position_t(start),
-        parse_position_t(cursor - 1));
+    return tokenize_result_t(found_sym, start, cursor);
 not_found:
     return tokenize_result_t(TOKEN_NOT_FOUND);
 }

--- a/src/parser/parse.cc
+++ b/src/parser/parse.cc
@@ -29,7 +29,7 @@ parse_result_t parse(parse_input_t& subject, parse_options_t& opts) {
     res.code = PARSE_OK;
     parse_context_t ctx(res, opts, subject);
     lexer_t& lex = ctx.lexer;
-    token_t* cur_tok;
+    token_t& cur_tok = lex.current_token;
 
     if (lex.cursor == lex.end_pos) {
         res.code = PARSE_INPUT_ERROR;
@@ -39,27 +39,27 @@ parse_result_t parse(parse_input_t& subject, parse_options_t& opts) {
 
     while (res.code == PARSE_OK) {
         cur_tok = lex.next();
-        if (cur_tok == NULL)
-            return res;
-        if (cur_tok->is_keyword()) {
+        if (cur_tok.symbol == SYMBOL_EOS)
+            break;
+        if (cur_tok.is_keyword()) {
             parse_statement(ctx);
             continue;
         }
-        if (cur_tok->is_punctuator()) {
+        if (cur_tok.is_punctuator()) {
             std::stringstream estr;
             estr << "Parse subject must either begin with a keyword or a "
                     "comment, but found punctuation." << std::endl;
             create_syntax_error_marker(ctx, estr, parse_position_t(lex.cursor));
             continue;
         }
-        if (cur_tok->is_literal()) {
+        if (cur_tok.is_literal()) {
             std::stringstream estr;
             estr << "Parse subject must either begin with a keyword or a "
                     "comment, but found literal." << std::endl;
             create_syntax_error_marker(ctx, estr, parse_position_t(lex.cursor));
             continue;
         }
-        if (cur_tok->is_identifier()) {
+        if (cur_tok.is_identifier()) {
             std::stringstream estr;
             estr << "Parse subject must either begin with a keyword or a "
                     "comment, but found identifier." << std::endl;

--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -23,7 +23,7 @@ typedef bool (*parse_func_t) (parse_context_t& ctx);
 // member (if ctx.options.disable_statement_construction is false
 bool parse_column_definition(
         parse_context_t& ctx,
-        token_t* cur_tok,
+        token_t& cur_tok,
         std::vector<std::unique_ptr<column_definition_t>>& column_defs);
 
 // Returns true if a data type descriptor clause can be parsed from the supplied
@@ -31,7 +31,7 @@ bool parse_column_definition(
 // have its data_type attribute set to an allocated data type descriptor
 bool parse_data_type_descriptor(
         parse_context_t& ctx,
-        token_t* cur_tok,
+        token_t& cur_tok,
         column_definition_t& column_def);
 
 // Returns true if a character string descriptor clause can be parsed from the
@@ -40,7 +40,7 @@ bool parse_data_type_descriptor(
 // or varchar_string_t descriptor
 bool parse_character_string(
         parse_context_t& ctx,
-        token_t* cur_tok,
+        token_t& cur_tok,
         column_definition_t& column_def);
 
 } // namespace sqltoast

--- a/src/parser/punctuator.cc
+++ b/src/parser/punctuator.cc
@@ -11,13 +11,8 @@ namespace sqltoast {
 tokenize_result_t token_punctuator(parse_position_t cursor) {
     const char c = *cursor;
     for (unsigned int x = 0; x < NUM_PUNCTUATORS; x++) {
-        if (c == punctuator_char_map[x]) {
-            return tokenize_result_t(
-                punctuator_symbol_map[x],
-                parse_position_t(cursor),
-                parse_position_t(cursor)
-            );
-        }
+        if (c == punctuator_char_map[x])
+            return tokenize_result_t(punctuator_symbol_map[x], cursor, cursor + 1);
     }
     return tokenize_result_t(TOKEN_NOT_FOUND);
 }

--- a/src/parser/punctuator.h
+++ b/src/parser/punctuator.h
@@ -12,16 +12,18 @@
 
 namespace sqltoast {
 
-const unsigned int NUM_PUNCTUATORS = 4;
+const unsigned int NUM_PUNCTUATORS = 5;
 
-static const char punctuator_char_map[4] = {
-    ';', // PUNCTUATOR_SEMICOLON
-    ',', // PUNCTUATOR_COMMA
-    '(', // PUNCTUATOR_LPAREN
-    ')', // PUNCTUATOR_RPAREN
+static const char punctuator_char_map[5] = {
+    '\0',
+    ';',
+    ',',
+    '(',
+    ')',
 };
 
-static const symbol_t punctuator_symbol_map[4] = {
+static const symbol_t punctuator_symbol_map[5] = {
+    SYMBOL_EOS,
     SYMBOL_SEMICOLON,
     SYMBOL_COMMA,
     SYMBOL_LPAREN,

--- a/src/parser/sequence.h
+++ b/src/parser/sequence.h
@@ -11,35 +11,42 @@
 #include "symbol.h"
 
 namespace sqltoast {
+// Returns true if the next sequence of symbols found in the supplied lexer
+// follows an expected supplied pattern. Uses
+// lexer_t::peek_from(parse_position_t) and therefore does not move the
+// lexer's underlying cursor state.
+inline bool has_sequence(lexer_t& lex, const symbol_t expected_sequence[], size_t num_expected) {
+    parse_position_t cur = lex.cursor;
+    symbol_t found_sym = lex.current_token.symbol;
+    for (unsigned int x = 0; x < num_expected; x++) {
+        if (found_sym != expected_sequence[x])
+            return false;
+        cur = lex.peek_from(cur, &found_sym);
+    }
+    return true;
+}
 
 // Returns true if the next sequence of symbols found in the tokens stack
 // follows an expected pattern. Logs a syntax error on the parse context if the
 // expected sequence of symbols was not found.
-inline bool follows_sequence(parse_context_t& ctx, const symbol_t expected_sequence[], size_t num_expected) {
+inline bool expect_sequence(parse_context_t& ctx, const symbol_t expected_sequence[], size_t num_expected) {
     symbol_t exp_sym;
     symbol_t cur_sym;
-    token_t* cur_tok;
+    token_t& cur_tok = ctx.lexer.current_token;
     for (unsigned int x = 0; x < num_expected; x++) {
         exp_sym = expected_sequence[x];
-        cur_tok = ctx.lexer.next();
-        if (cur_tok == NULL)
-            goto err_unexpected;
-        cur_sym = (*cur_tok).symbol;
+        cur_sym = cur_tok.symbol;
         if (cur_sym != exp_sym)
             goto err_unexpected;
+        cur_tok = ctx.lexer.next();
     }
     return true;
 err_unexpected:
     {
         std::stringstream estr;
         parse_position_t err_pos = ctx.lexer.cursor;
-        if (cur_tok == NULL) {
-            estr << "Expected " << symbol_map::to_string(exp_sym) << " but found EOS";
-        } else {
-            cur_sym = (*cur_tok).symbol;
-            estr << "Expected " << symbol_map::to_string(exp_sym) << " but found "
-                 << symbol_map::to_string(cur_sym);
-        }
+        estr << "Expected " << symbol_map::to_string(exp_sym) << " but found "
+             << symbol_map::to_string(cur_sym);
         estr << std::endl;
         create_syntax_error_marker(ctx, estr, err_pos);
         return false;

--- a/src/parser/symbol.cc
+++ b/src/parser/symbol.cc
@@ -11,8 +11,8 @@ namespace sqltoast {
 symbol_map::symbol_map_t  _init_symbol_map() {
     symbol_map::symbol_map_t m;
 
-    m[SYMBOL_SOS] = std::string("<< start of input >>");
-    m[SYMBOL_EOS] = std::string("<< end of input >>");
+    m[SYMBOL_SOS] = std::string("SOS");
+    m[SYMBOL_EOS] = std::string("EOS");
 
     // Punctuators
     m[SYMBOL_SEMICOLON] = std::string("SEMICOLON");

--- a/src/parser/symbol.h
+++ b/src/parser/symbol.h
@@ -29,6 +29,7 @@ namespace sqltoast {
 // the SYMBOL_CREATE or SYMBOL_DATABASE symbols...
 typedef enum symbol {
     SYMBOL_NONE,
+    SYMBOL_ERROR,
 
     SYMBOL_SOS, // Start of the input stream
     SYMBOL_EOS, // End of the input stream

--- a/src/parser/token.cc
+++ b/src/parser/token.cc
@@ -15,11 +15,21 @@ std::ostream& operator<< (std::ostream& out, const token_t& token) {
     }
     if (token.is_literal()){
         // TODO(jaypipes): Add typing of literal...
-        out << "literal[length: " << token.lexeme.size() << "]";
+        size_t tok_len = token.lexeme.size();
+        if (tok_len < 20) {
+            out << "literal[" << std::string(token.lexeme.start, token.lexeme.end) << "]";
+        } else {
+            out << "literal[length: " << tok_len << "]";
+        }
         return out;
     }
     if (token.is_identifier()){
-        out << "identifier[length: " << token.lexeme.size() << "]";
+        size_t tok_len = token.lexeme.size();
+        if (tok_len < 20) {
+            out << "identifier[" << std::string(token.lexeme.start, token.lexeme.end) << "]";
+        } else {
+            out << "identifier[length: " << tok_len << "]";
+        }
         return out;
     }
     if (token.symbol == SYMBOL_COMMENT) {


### PR DESCRIPTION
gets rid of the token_t* pointers and instead has a reference to a
token_t& used in the parse_xxx() functions. This reference to token_t&
is now always going to contain a symbol, possibly the new SYMBOL_EOS or
SYMBOL_ERROR.