### PR TITLE
Support UNIQUE, PRIMARY KEY table constraints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,13 @@ SET(SQLTOAST_VERSION_MAJOR 0)
 SET(SQLTOAST_VERSION_MINOR 1)
 SET(LIBSQLTOAST_SOURCES
     src/identifier.cc
+    src/constraint.cc
     src/column_definition.cc
     src/data_type.cc
     src/parser/column_definition.cc
     src/parser/data_type_descriptor.cc
     src/parser/comment.cc
+    src/parser/constraint.cc
     src/parser/context.cc
     src/parser/error.cc
     src/parser/keyword.cc

--- a/include/column_definition.h
+++ b/include/column_definition.h
@@ -43,66 +43,15 @@ typedef struct default_descriptor {
 
 std::ostream& operator<< (std::ostream& out, const default_descriptor_t& column_def);
 
-typedef enum column_constraint_type {
-    COLUMN_CONSTRAINT_TYPE_NOT_NULL,
-    COLUMN_CONSTRAINT_TYPE_UNIQUE,
-    COLUMN_CONSTRAINT_TYPE_PRIMARY_KEY,
-    COLUMN_CONSTRAINT_TYPE_REFERENCES,
-    COLUMN_CONSTRAINT_TYPE_CHECK
-} column_constraint_type_t;
-
-typedef struct column_constraint {
-    column_constraint_type_t type;
-    std::unique_ptr<identifier_t> name;
-    column_constraint(column_constraint_type_t type) :
-        type(type)
-    {}
-} column_constraint_t;
-
-std::ostream& operator<< (std::ostream& out, const column_constraint_t& constraint);
-
-typedef enum references_match_type {
-    REFERENCES_MATCH_TYPE_NONE,
-    REFERENCES_MATCH_TYPE_FULL,
-    REFERENCES_MATCH_TYPE_PARTIAL
-} references_match_type_t;
-
-typedef enum referential_action {
-    REFERENTIAL_ACTION_NONE,
-    REFERENTIAL_ACTION_CASCADE,
-    REFERENTIAL_ACTION_SET_NULL,
-    REFERENTIAL_ACTION_SET_DEFAULT
-} referential_action_t;
-
-typedef struct references_constraint : column_constraint_t {
-    identifier_t table_name;
-    references_match_type_t match_type;
-    referential_action_t on_update;
-    referential_action_t on_delete;
-    std::vector<identifier_t> column_names;
-    references_constraint(
-            identifier_t& table_name,
-            references_match_type_t match_type,
-            referential_action_t on_update,
-            referential_action_t on_delete) :
-        column_constraint(COLUMN_CONSTRAINT_TYPE_REFERENCES),
-        table_name(table_name),
-        match_type(match_type),
-        on_update(on_update),
-        on_delete(on_delete)
-    {}
-} references_constraint_t;
-
-std::ostream& operator<< (std::ostream& out, const references_constraint_t& constraint);
-
 typedef struct column_definition {
     identifier_t id;
+    bool is_nullable;
     std::unique_ptr<data_type_descriptor_t> data_type;
     std::unique_ptr<default_descriptor_t> default_descriptor;
     std::unique_ptr<identifier_t> collate;
-    std::vector<std::unique_ptr<column_constraint_t>> constraints;
     column_definition(identifier_t& id) :
-        id(id)
+        id(id),
+        is_nullable(true)
     {}
 } column_definition_t;
 

--- a/include/constraint.h
+++ b/include/constraint.h
@@ -1,0 +1,81 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#ifndef SQLTOAST_CONSTRAINT_H
+#define SQLTOAST_CONSTRAINT_H
+
+#include <memory>
+#include <vector>
+#include <ostream>
+
+#include "data_type.h"
+#include "identifier.h"
+
+namespace sqltoast {
+
+typedef enum constraint_type {
+    CONSTRAINT_TYPE_UNIQUE,
+    CONSTRAINT_TYPE_PRIMARY_KEY,
+    CONSTRAINT_TYPE_FOREIGN_KEY,
+    CONSTRAINT_TYPE_CHECK
+} constraint_type_t;
+
+typedef struct constraint {
+    constraint_type_t type;
+    std::unique_ptr<identifier_t> name;
+    std::vector<identifier_t> columns;
+    constraint(constraint_type_t type) :
+        type(type)
+    {}
+} constraint_t;
+
+std::ostream& operator<< (std::ostream& out, const constraint_t& constraint);
+
+typedef struct unique_constraint : constraint_t {
+    unique_constraint(bool is_primary) :
+        constraint_t(is_primary ? CONSTRAINT_TYPE_PRIMARY_KEY : CONSTRAINT_TYPE_UNIQUE)
+    {}
+} unique_constraint_t;
+
+std::ostream& operator<< (std::ostream& out, const unique_constraint_t& constraint);
+
+typedef enum match_type {
+    MATCH_TYPE_NONE,
+    MATCH_TYPE_FULL,
+    MATCH_TYPE_PARTIAL
+} match_type_t;
+
+typedef enum referential_action {
+    REFERENTIAL_ACTION_NONE,
+    REFERENTIAL_ACTION_CASCADE,
+    REFERENTIAL_ACTION_SET_NULL,
+    REFERENTIAL_ACTION_SET_DEFAULT
+} referential_action_t;
+
+typedef struct foreign_key_constraint : constraint_t {
+    identifier_t table_name;
+    match_type_t match_type;
+    referential_action_t on_update;
+    referential_action_t on_delete;
+    std::vector<identifier_t> referenced_columns;
+    foreign_key_constraint(
+            identifier_t& table_name,
+            match_type_t match_type,
+            referential_action_t on_update,
+            referential_action_t on_delete) :
+        constraint(CONSTRAINT_TYPE_FOREIGN_KEY),
+        table_name(table_name),
+        match_type(match_type),
+        on_update(on_update),
+        on_delete(on_delete)
+    {}
+} foreign_key_constraint_t;
+
+std::ostream& operator<< (std::ostream& out, const foreign_key_constraint_t& constraint);
+
+} // namespace sqltoast
+
+#endif /* SQLTOAST_CONSTRAINT_H */

--- a/include/statements/create_table.h
+++ b/include/statements/create_table.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "column_definition.h"
+#include "constraint.h"
 #include "identifier.h"
 #include "statement.h"
 
@@ -28,6 +29,7 @@ typedef struct create_table : statement_t {
     table_type_t table_type;
     identifier_t table_identifier;
     std::vector<std::unique_ptr<column_definition_t>> column_definitions;
+    std::vector<std::unique_ptr<constraint_t>> constraints;
     create_table(table_type_t table_type, identifier_t& table_id) :
         statement_t(STATEMENT_TYPE_CREATE_TABLE),
         table_type(table_type),

--- a/src/column_definition.cc
+++ b/src/column_definition.cc
@@ -8,87 +8,6 @@
 
 namespace sqltoast {
 
-std::ostream& operator<< (std::ostream& out, const column_constraint_t& constraint) {
-    if (constraint.name.get())
-        out << "CONSTRAINT " << *constraint.name << " ";
-    switch (constraint.type) {
-        case COLUMN_CONSTRAINT_TYPE_NOT_NULL:
-            out << "NOT NULL";
-            break;
-        case COLUMN_CONSTRAINT_TYPE_UNIQUE:
-            out << "UNIQUE";
-            break;
-        case COLUMN_CONSTRAINT_TYPE_PRIMARY_KEY:
-            out << "PRIMARY KEY";
-            break;
-        case COLUMN_CONSTRAINT_TYPE_REFERENCES:
-            {
-                const references_constraint_t& ref_c = static_cast<const references_constraint_t&>(constraint);
-                out << ref_c;
-            }
-            break;
-        case COLUMN_CONSTRAINT_TYPE_CHECK:
-            out << "CHECK ";
-            // TODO
-            break;
-        default:
-            break;
-    }
-    return out;
-}
-
-std::ostream& operator<< (std::ostream& out, const references_constraint_t& constraint) {
-        out << "REFERENCES " << constraint.table_name;
-        size_t num_columns = constraint.column_names.size();
-        if (num_columns > 0) {
-            out << "(";
-            size_t x = 0;
-            for (const identifier_t& col_name : constraint.column_names) {
-                out << col_name;
-                if (x++ != (num_columns - 1))
-                    out << ",";
-            }
-            out << ")";
-        }
-        switch (constraint.match_type) {
-            case REFERENCES_MATCH_TYPE_FULL:
-                out << " MATCH FULL";
-                break;
-            case REFERENCES_MATCH_TYPE_PARTIAL:
-                out << " MATCH PARTIAL";
-                break;
-            default:
-                break;
-        }
-        switch (constraint.on_update) {
-            case REFERENTIAL_ACTION_SET_NULL:
-                out << " ON UPDATE SET NULL";
-                break;
-            case REFERENTIAL_ACTION_SET_DEFAULT:
-                out << " ON UPDATE SET DEFAULT";
-                break;
-            case REFERENTIAL_ACTION_CASCADE:
-                out << " ON UPDATE CASCADE";
-                break;
-            default:
-                break;
-        }
-        switch (constraint.on_delete) {
-            case REFERENTIAL_ACTION_SET_NULL:
-                out << " ON DELETE SET NULL";
-                break;
-            case REFERENTIAL_ACTION_SET_DEFAULT:
-                out << " ON DELETE SET DEFAULT";
-                break;
-            case REFERENTIAL_ACTION_CASCADE:
-                out << " ON DELETE CASCADE";
-                break;
-            default:
-                break;
-        }
-        return out;
-}
-
 std::ostream& operator<< (std::ostream& out, const default_descriptor_t& default_desc) {
     out << "DEFAULT ";
     switch (default_desc.type) {
@@ -139,13 +58,8 @@ std::ostream& operator<< (std::ostream& out, const column_definition_t& column_d
     if (column_def.default_descriptor.get()) {
         out << " " << *column_def.default_descriptor;
     }
-    if (column_def.constraints.size() > 0) {
-        for (auto constraint_it = column_def.constraints.begin();
-             constraint_it != column_def.constraints.end();
-             constraint_it++) {
-            out << " " << *(*constraint_it);
-        }
-    }
+    if (! column_def.is_nullable)
+        out << " NOT NULL";
     if (column_def.collate.get()) {
         out << " COLLATE " << *column_def.collate;
     }

--- a/src/constraint.cc
+++ b/src/constraint.cc
@@ -1,0 +1,125 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#include "constraint.h"
+
+namespace sqltoast {
+
+std::ostream& operator<< (std::ostream& out, const constraint_t& constraint) {
+    if (constraint.name.get())
+        out << "CONSTRAINT " << *constraint.name << " ";
+    switch (constraint.type) {
+        case CONSTRAINT_TYPE_UNIQUE:
+        case CONSTRAINT_TYPE_PRIMARY_KEY:
+            {
+                const unique_constraint_t& uniq_c = static_cast<const unique_constraint_t&>(constraint);
+                out << uniq_c;
+            }
+            break;
+        case CONSTRAINT_TYPE_FOREIGN_KEY:
+            {
+                const foreign_key_constraint_t& ref_c = static_cast<const foreign_key_constraint_t&>(constraint);
+                out << ref_c;
+            }
+            break;
+        case CONSTRAINT_TYPE_CHECK:
+            out << "CHECK ";
+            // TODO
+            break;
+        default:
+            break;
+    }
+    return out;
+}
+
+std::ostream& operator<< (std::ostream& out, const unique_constraint_t& constraint) {
+    switch (constraint.type) {
+        case CONSTRAINT_TYPE_UNIQUE:
+            out << "UNIQUE";
+            break;
+        case CONSTRAINT_TYPE_PRIMARY_KEY:
+            out << "PRIMARY KEY";
+            break;
+        default:
+            // Should never happen...
+            break;
+    }
+    size_t x = 0;
+    size_t num_columns = constraint.columns.size();
+    if (num_columns > 0) {
+        out << "(";
+        for (auto col : constraint.columns) {
+            out << col;
+            if (x++ < (num_columns - 1)) {
+                out << ",";
+            }
+        }
+        out << ")";
+    }
+    return out;
+}
+
+std::ostream& operator<< (std::ostream& out, const foreign_key_constraint_t& constraint) {
+        size_t num_columns = constraint.columns.size();
+        size_t x = 0;
+        out << "FOREIGN KEY (";
+        for (const identifier_t& col_name : constraint.columns) {
+            out << col_name;
+            if (x++ != (num_columns - 1))
+                out << ",";
+        }
+        size_t num_referenced_columns = constraint.referenced_columns.size();
+        out << ") REFERENCES " << constraint.table_name;
+        if (num_referenced_columns > 0) {
+            out << "(";
+            x = 0;
+            for (const identifier_t& col_name : constraint.referenced_columns) {
+                out << col_name;
+                if (x++ != (num_referenced_columns - 1))
+                    out << ",";
+            }
+            out << ")";
+        }
+        switch (constraint.match_type) {
+            case MATCH_TYPE_FULL:
+                out << " MATCH FULL";
+                break;
+            case MATCH_TYPE_PARTIAL:
+                out << " MATCH PARTIAL";
+                break;
+            default:
+                break;
+        }
+        switch (constraint.on_update) {
+            case REFERENTIAL_ACTION_SET_NULL:
+                out << " ON UPDATE SET NULL";
+                break;
+            case REFERENTIAL_ACTION_SET_DEFAULT:
+                out << " ON UPDATE SET DEFAULT";
+                break;
+            case REFERENTIAL_ACTION_CASCADE:
+                out << " ON UPDATE CASCADE";
+                break;
+            default:
+                break;
+        }
+        switch (constraint.on_delete) {
+            case REFERENTIAL_ACTION_SET_NULL:
+                out << " ON DELETE SET NULL";
+                break;
+            case REFERENTIAL_ACTION_SET_DEFAULT:
+                out << " ON DELETE SET DEFAULT";
+                break;
+            case REFERENTIAL_ACTION_CASCADE:
+                out << " ON DELETE CASCADE";
+                break;
+            default:
+                break;
+        }
+        return out;
+}
+
+} // namespace sqltoast

--- a/src/parser/constraint.cc
+++ b/src/parser/constraint.cc
@@ -1,0 +1,132 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#include <iostream>
+#include <cctype>
+#include <sstream>
+
+#include "parser/parse.h"
+#include "parser/error.h"
+#include "parser/token.h"
+
+namespace sqltoast {
+
+//
+// Parses a table constraint, which follows this EBNF grammar for ANSI-92:
+//
+// <table constraint definition> ::=
+//     [ <constraint name definition> ] <table constraint> [ <constraint check time> ]
+//
+// <table constraint> ::=
+//     <unique constraint definition>
+//     | <referential constraint definition>
+//     | <check constraint definition>
+bool parse_constraint(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::vector<std::unique_ptr<constraint_t>>& constraints) {
+    lexer_t& lex = ctx.lexer;
+    symbol_t cur_sym = cur_tok.symbol;
+    std::unique_ptr<identifier_t> constraint_name_p;
+    std::unique_ptr<constraint_t> constraint_p;
+
+    // BEGIN STATE MACHINE
+
+    if (cur_sym == SYMBOL_CONSTRAINT) {
+        cur_tok = ctx.lexer.next();
+        goto expect_constraint_name;
+    }
+    goto expect_constraint_type;
+expect_constraint_name:
+    cur_sym = cur_tok.symbol;
+    if (cur_sym != SYMBOL_IDENTIFIER)
+        goto err_expect_identifier;
+    constraint_name_p = std::make_unique<identifier_t>(cur_tok.lexeme);
+    cur_tok = lex.next();
+    goto expect_constraint_type;
+err_expect_identifier:
+    expect_error(ctx, SYMBOL_IDENTIFIER);
+    return false;
+expect_constraint_type:
+    cur_sym = cur_tok.symbol;
+    switch (cur_sym) {
+        case SYMBOL_UNIQUE:
+            cur_tok = ctx.lexer.next();
+            constraint_p = std::move(std::make_unique<unique_constraint_t>(false));
+            goto expect_col_list;
+        case SYMBOL_PRIMARY:
+            cur_tok = ctx.lexer.next();
+            goto expect_key;
+        case SYMBOL_FOREIGN:
+        case SYMBOL_CHECK:
+            // TODO
+        default:
+            if (! constraint_name_p.get())
+                goto err_expect_constraint_type;
+            // Just return false, since callers could be looking for a column
+            // definition (on the table)
+            return false;
+    }
+err_expect_constraint_type:
+    expect_any_error(ctx, {SYMBOL_FOREIGN, SYMBOL_UNIQUE, SYMBOL_PRIMARY, SYMBOL_CHECK});
+    return false;
+expect_key:
+    cur_sym = cur_tok.symbol;
+    if (cur_sym != SYMBOL_KEY)
+        goto err_expect_key;
+    cur_tok = lex.next();
+    constraint_p = std::move(std::make_unique<unique_constraint_t>(true));
+    goto expect_col_list;
+err_expect_key:
+    expect_error(ctx, SYMBOL_KEY);
+    return false;
+expect_col_list:
+    // We get here if we've successfully parsed the constraint type (UNIQUE,
+    // PRIMARY KEY or FOREIGN KEY <referencing column>) and now we expect a
+    // parens-enclosed, comma-delimited list of column names
+    cur_sym = cur_tok.symbol;
+    if (cur_sym != SYMBOL_LPAREN)
+        goto err_expect_lparen;
+    cur_tok = lex.next();
+    goto process_column;
+err_expect_lparen:
+    expect_error(ctx, SYMBOL_LPAREN);
+    return false;
+process_column:
+    cur_sym = cur_tok.symbol;
+    if (cur_sym != SYMBOL_IDENTIFIER)
+        goto err_expect_identifier;
+    constraint_p->columns.emplace_back(identifier_t(cur_tok.lexeme));
+    cur_tok = lex.next();
+    cur_sym = cur_tok.symbol;
+    if (cur_sym == SYMBOL_COMMA) {
+        cur_tok = lex.next();
+        goto process_column;
+    }
+    goto expect_rparen;
+expect_rparen:
+    // We get here after successfully parsing a column list and now we're
+    // looking for that closing parentheses
+    cur_sym = cur_tok.symbol;
+    if (cur_sym != SYMBOL_RPAREN)
+        goto err_expect_rparen;
+    cur_tok = lex.next();
+    goto push_constraint;
+err_expect_rparen:
+    expect_error(ctx, SYMBOL_RPAREN);
+    return false;
+push_constraint:
+    {
+        if (ctx.opts.disable_statement_construction)
+            return true;
+        if (constraint_name_p.get())
+            constraint_p->name = std::move(constraint_name_p);
+        constraints.emplace_back(std::move(constraint_p));
+        return true;
+    }
+}
+
+} // namespace sqltoast

--- a/src/parser/keyword.cc
+++ b/src/parser/keyword.cc
@@ -46,6 +46,7 @@ kw_jump_table_t _init_kw_jump_table(char lead_char) {
         case 'f':
             t.emplace_back(kw_jump_table_entry_t(SYMBOL_FLOAT, "FLOAT"));
             t.emplace_back(kw_jump_table_entry_t(SYMBOL_FULL, "FULL"));
+            t.emplace_back(kw_jump_table_entry_t(SYMBOL_FOREIGN, "FOREIGN"));
             return t;
         case 'g':
             t.emplace_back(kw_jump_table_entry_t(SYMBOL_GLOBAL, "GLOBAL"));

--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "column_definition.h"
+#include "constraint.h"
 #include "context.h"
 #include "token.h"
 
@@ -18,13 +19,22 @@ namespace sqltoast {
 
 typedef bool (*parse_func_t) (parse_context_t& ctx);
 
+// Returns true if a table constraint can be parsed from the supplied token
+// iterator. If the function returns true, constraints will have a new member
+// (if ctx.options.disable_statement_construction is false
+bool parse_constraint(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::vector<std::unique_ptr<constraint_t>>& constraints);
+
 // Returns true if a column definition clause can be parsed from the supplied
 // token iterator. If the function returns true, column_defs will have a new
 // member (if ctx.options.disable_statement_construction is false
 bool parse_column_definition(
         parse_context_t& ctx,
         token_t& cur_tok,
-        std::vector<std::unique_ptr<column_definition_t>>& column_defs);
+        std::vector<std::unique_ptr<column_definition_t>>& column_defs,
+        std::vector<std::unique_ptr<constraint_t>>& constraints);
 
 // Returns true if a default clause can be parsed from the supplied
 // token iterator. If the function returns true, column_def will have a its
@@ -40,7 +50,8 @@ bool parse_default_clause(
 bool parse_column_constraint(
         parse_context_t& ctx,
         token_t& cur_tok,
-        column_definition_t& column_def);
+        column_definition_t& column_def,
+        std::vector<std::unique_ptr<constraint_t>>& constraints);
 
 // Returns true if a references column constraint can be parsed from the
 // supplied token iterator. If the function returns true, column_def will have
@@ -49,7 +60,8 @@ bool parse_references_constraint(
         parse_context_t& ctx,
         token_t& cur_tok,
         column_definition_t& column_def,
-        std::unique_ptr<identifier_t>& constraint_name);
+        std::unique_ptr<identifier_t>& constraint_name,
+        std::vector<std::unique_ptr<constraint_t>>& constraints);
 
 // Returns true if a collate clause can be parsed from the supplied
 // token iterator. If the function returns true, column_def will have a its

--- a/src/parser/symbol.cc
+++ b/src/parser/symbol.cc
@@ -44,6 +44,7 @@ symbol_map::symbol_map_t  _init_symbol_map() {
     m[SYMBOL_DROP] = std::string("DROP");
     m[SYMBOL_DOUBLE] = std::string("DOUBLE");
     m[SYMBOL_FLOAT] = std::string("FLOAT");
+    m[SYMBOL_FOREIGN] = std::string("FOREIGN");
     m[SYMBOL_FULL] = std::string("FULL");
     m[SYMBOL_GLOBAL] = std::string("GLOBAL");
     m[SYMBOL_HOUR] = std::string("HOUR");

--- a/src/parser/symbol.h
+++ b/src/parser/symbol.h
@@ -64,6 +64,7 @@ typedef enum symbol {
     SYMBOL_DOUBLE,
     SYMBOL_DROP,
     SYMBOL_FLOAT,
+    SYMBOL_FOREIGN,
     SYMBOL_FULL,
     SYMBOL_GLOBAL,
     SYMBOL_HOUR,

--- a/src/statements/create_table.cc
+++ b/src/statements/create_table.cc
@@ -29,6 +29,14 @@ const std::string create_table::to_string() {
             cdef_it++) {
         ss << std::endl << "      " << *(*cdef_it);
     }
+    if (constraints.size() > 0) {
+        ss << std::endl << "    constraints:";
+        for (auto constraint_it = constraints.begin();
+             constraint_it != constraints.end();
+             constraint_it++) {
+            ss << std::endl << "      " << *(*constraint_it);
+        }
+    }
     ss << ">" << std::endl;
 
     return ss.str();


### PR DESCRIPTION
Reworks the column_constraint_t to just constraint_t and applies them
against the table, even if found during processing of a column
definition.

Still working on the FOREIGN KEY and CHECK constraints on tables.

Issue #6