### PR TITLE
break out small parsers from parse_references_constraint()

### DIFF
--- a/include/constraint.h
+++ b/include/constraint.h
@@ -56,18 +56,18 @@ typedef enum referential_action {
 } referential_action_t;
 
 typedef struct foreign_key_constraint : constraint_t {
-    identifier_t table_name;
+    identifier_t referenced_table;
     match_type_t match_type;
     referential_action_t on_update;
     referential_action_t on_delete;
     std::vector<identifier_t> referenced_columns;
     foreign_key_constraint(
-            identifier_t& table_name,
+            identifier_t& ref_table,
             match_type_t match_type,
             referential_action_t on_update,
             referential_action_t on_delete) :
         constraint(CONSTRAINT_TYPE_FOREIGN_KEY),
-        table_name(table_name),
+        referenced_table(ref_table),
         match_type(match_type),
         on_update(on_update),
         on_delete(on_delete)

--- a/src/constraint.cc
+++ b/src/constraint.cc
@@ -72,7 +72,7 @@ std::ostream& operator<< (std::ostream& out, const foreign_key_constraint_t& con
                 out << ",";
         }
         size_t num_referenced_columns = constraint.referenced_columns.size();
-        out << ") REFERENCES " << constraint.table_name;
+        out << ") REFERENCES " << constraint.referenced_table;
         if (num_referenced_columns > 0) {
             out << "(";
             x = 0;

--- a/src/parser/column_definition.cc
+++ b/src/parser/column_definition.cc
@@ -325,7 +325,7 @@ bool parse_references_constraint(
         std::vector<std::unique_ptr<constraint_t>>& constraints) {
     lexer_t& lex = ctx.lexer;
     symbol_t cur_sym = cur_tok.symbol;
-    lexeme_t table_ident;
+    lexeme_t ref_table;
     std::vector<identifier_t> referenced_column_names;
     bool found_on_update = false;
     bool found_on_delete = false;
@@ -336,7 +336,7 @@ bool parse_references_constraint(
     cur_sym = cur_tok.symbol;
     if (cur_sym != SYMBOL_IDENTIFIER)
         goto err_expect_identifier;
-    fill_lexeme(cur_tok, table_ident);
+    fill_lexeme(cur_tok, ref_table);
     cur_tok = lex.next();
     goto optional_column_names;
 err_expect_identifier:
@@ -532,9 +532,9 @@ push_constraint:
     {
         if (ctx.opts.disable_statement_construction)
             return true;
-        identifier_t table_name(table_ident);
+        identifier_t ref_table_ident(ref_table);
         std::unique_ptr<foreign_key_constraint_t> constraint_p =
-            std::make_unique<foreign_key_constraint_t>(table_name, match_type, on_update, on_delete);
+            std::make_unique<foreign_key_constraint_t>(ref_table_ident, match_type, on_update, on_delete);
         if (constraint_name.get())
             constraint_p->name = std::move(constraint_name);
         constraint_p->columns.emplace_back(std::move(column_def.id));

--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -63,6 +63,14 @@ bool parse_references_constraint(
         std::unique_ptr<identifier_t>& constraint_name,
         std::vector<std::unique_ptr<constraint_t>>& constraints);
 
+// Returns true if one or more identifiers, delimited by commas, can be parsed
+// from the supplied token iterator. If the function returns true, identifiers
+// will have been populated with identifier_t structs.
+bool parse_identifier_list(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::vector<identifier_t>& identifiers);
+
 // Returns true if a match type can be parsed from the
 // supplied token iterator. If the function returns true, the match_type
 // argument will be set to the found match type.

--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -63,6 +63,14 @@ bool parse_references_constraint(
         std::unique_ptr<identifier_t>& constraint_name,
         std::vector<std::unique_ptr<constraint_t>>& constraints);
 
+// Returns true if a match type can be parsed from the
+// supplied token iterator. If the function returns true, the match_type
+// argument will be set to the found match type.
+bool parse_match_type(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        match_type* match_type);
+
 // Returns true if a collate clause can be parsed from the supplied
 // token iterator. If the function returns true, column_def will have a its
 // collate member populated.

--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -71,6 +71,14 @@ bool parse_match_type(
         token_t& cur_tok,
         match_type* match_type);
 
+// Returns true if a referential action can be parsed from the
+// supplied token iterator. If the function returns true, the action
+// argument will be set to the found referential action.
+bool parse_referential_action(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        referential_action_t* action);
+
 // Returns true if a collate clause can be parsed from the supplied
 // token iterator. If the function returns true, column_def will have a its
 // collate member populated.

--- a/src/parser/statements/create_table.cc
+++ b/src/parser/statements/create_table.cc
@@ -130,9 +130,12 @@ bool parse_create_table(parse_context_t& ctx) {
         // We get here after finding the LPAREN opening the <table element
         // list> clause. Now we expect to find one or more column or constraint
         // definitions
-        if (! parse_column_definition(ctx, cur_tok, column_defs, constraints) &&
-                ! parse_constraint(ctx, cur_tok, constraints))
-            goto err_expect_column_def_or_constraint;
+        if (! parse_column_definition(ctx, cur_tok, column_defs, constraints)) {
+            if (ctx.result.code == PARSE_SYNTAX_ERROR)
+                return false;
+            if (! parse_constraint(ctx, cur_tok, constraints))
+                goto err_expect_column_def_or_constraint;
+        }
         goto expect_table_list_close;
 err_expect_column_def_or_constraint:
     if (ctx.result.code == PARSE_SYNTAX_ERROR)

--- a/src/parser/statements/create_table.cc
+++ b/src/parser/statements/create_table.cc
@@ -60,83 +60,83 @@ bool parse_create_table(parse_context_t& ctx) {
             return false;
     }
 
-    table_kw_or_table_type:
-        // We get here after successfully finding the CREATE symbol. We can
-        // either match the table keyword or the table type clause
-        if (cur_sym == SYMBOL_GLOBAL) {
-            table_type = statements::TABLE_TYPE_TEMPORARY_GLOBAL;
-            cur_tok = lex.next();
-            goto expect_temporary;
-        } else if (cur_sym == SYMBOL_LOCAL) {
-            table_type = statements::TABLE_TYPE_TEMPORARY_LOCAL;
-            cur_tok = lex.next();
-            goto expect_temporary;
-        } else if (cur_sym == SYMBOL_TEMPORARY) {
-            table_type = statements::TABLE_TYPE_TEMPORARY_GLOBAL;
-            cur_tok = lex.next();
-            goto expect_table;
-        }
-    expect_temporary:
-        // We get here if we successfully matched CREATE followed by either the
-        // GLOBAL or LOCAL symbol. If this is the case, we expect to find the
-        // TEMPORARY keyword followed by the TABLE keyword.
-        cur_sym = cur_tok.symbol;
-        if (cur_sym == SYMBOL_TEMPORARY) {
-            cur_tok = lex.next();
-            goto expect_table;
-        }
-        goto err_expect_temporary;
-    err_expect_temporary:
-        expect_error(ctx, SYMBOL_TEMPORARY);
-        return false;
-    expect_table:
-        cur_sym = cur_tok.symbol;
-        if (cur_sym == SYMBOL_TABLE) {
-            cur_tok = lex.next();
-            goto expect_table_name;
-        }
-        goto err_expect_table;
-    err_expect_table:
-        expect_error(ctx, SYMBOL_TABLE);
-        return false;
-    expect_table_name:
-        // We get here after successfully finding CREATE followed by the TABLE
-        // symbol (after optionally processing the table type modifier). We now
-        // need to find an identifier
-        cur_sym = cur_tok.symbol;
-        if (cur_sym == SYMBOL_IDENTIFIER) {
-            fill_lexeme(cur_tok, ident);
-            cur_tok = lex.next();
-            goto expect_table_list_open;
-        }
-        goto err_expect_identifier;
-    err_expect_identifier:
-        expect_error(ctx, SYMBOL_IDENTIFIER);
-        return false;
-    expect_table_list_open:
-        // We get here after successfully finding the CREATE ... TABLE <table name>
-        // part of the statement. We now expect to find the <table element
-        // list> clause
-        cur_sym = cur_tok.symbol;
-        if (cur_sym == SYMBOL_LPAREN) {
-            cur_tok = lex.next();
-            goto expect_table_list_element;
-        }
-        goto err_expect_lparen;
-    err_expect_lparen:
-        expect_error(ctx, SYMBOL_LPAREN);
-        return false;
-    expect_table_list_element:
-        // We get here after finding the LPAREN opening the <table element
-        // list> clause. Now we expect to find one or more column or constraint
-        // definitions
-        if (! parse_column_definition(ctx, cur_tok, column_defs, constraints)) {
-            if (ctx.result.code == PARSE_SYNTAX_ERROR)
-                return false;
-            if (! parse_constraint(ctx, cur_tok, constraints))
-                goto err_expect_column_def_or_constraint;
-        }
-        goto expect_table_list_close;
+table_kw_or_table_type:
+    // We get here after successfully finding the CREATE symbol. We can
+    // either match the table keyword or the table type clause
+    if (cur_sym == SYMBOL_GLOBAL) {
+        table_type = statements::TABLE_TYPE_TEMPORARY_GLOBAL;
+        cur_tok = lex.next();
+        goto expect_temporary;
+    } else if (cur_sym == SYMBOL_LOCAL) {
+        table_type = statements::TABLE_TYPE_TEMPORARY_LOCAL;
+        cur_tok = lex.next();
+        goto expect_temporary;
+    } else if (cur_sym == SYMBOL_TEMPORARY) {
+        table_type = statements::TABLE_TYPE_TEMPORARY_GLOBAL;
+        cur_tok = lex.next();
+        goto expect_table;
+    }
+expect_temporary:
+    // We get here if we successfully matched CREATE followed by either the
+    // GLOBAL or LOCAL symbol. If this is the case, we expect to find the
+    // TEMPORARY keyword followed by the TABLE keyword.
+    cur_sym = cur_tok.symbol;
+    if (cur_sym == SYMBOL_TEMPORARY) {
+        cur_tok = lex.next();
+        goto expect_table;
+    }
+    goto err_expect_temporary;
+err_expect_temporary:
+    expect_error(ctx, SYMBOL_TEMPORARY);
+    return false;
+expect_table:
+    cur_sym = cur_tok.symbol;
+    if (cur_sym == SYMBOL_TABLE) {
+        cur_tok = lex.next();
+        goto expect_table_name;
+    }
+    goto err_expect_table;
+err_expect_table:
+    expect_error(ctx, SYMBOL_TABLE);
+    return false;
+expect_table_name:
+    // We get here after successfully finding CREATE followed by the TABLE
+    // symbol (after optionally processing the table type modifier). We now
+    // need to find an identifier
+    cur_sym = cur_tok.symbol;
+    if (cur_sym == SYMBOL_IDENTIFIER) {
+        fill_lexeme(cur_tok, ident);
+        cur_tok = lex.next();
+        goto expect_table_list_open;
+    }
+    goto err_expect_identifier;
+err_expect_identifier:
+    expect_error(ctx, SYMBOL_IDENTIFIER);
+    return false;
+expect_table_list_open:
+    // We get here after successfully finding the CREATE ... TABLE <table name>
+    // part of the statement. We now expect to find the <table element
+    // list> clause
+    cur_sym = cur_tok.symbol;
+    if (cur_sym == SYMBOL_LPAREN) {
+        cur_tok = lex.next();
+        goto expect_table_list_element;
+    }
+    goto err_expect_lparen;
+err_expect_lparen:
+    expect_error(ctx, SYMBOL_LPAREN);
+    return false;
+expect_table_list_element:
+    // We get here after finding the LPAREN opening the <table element
+    // list> clause. Now we expect to find one or more column or constraint
+    // definitions
+    if (! parse_column_definition(ctx, cur_tok, column_defs, constraints)) {
+        if (ctx.result.code == PARSE_SYNTAX_ERROR)
+            return false;
+        if (! parse_constraint(ctx, cur_tok, constraints))
+            goto err_expect_column_def_or_constraint;
+    }
+    goto expect_table_list_close;
 err_expect_column_def_or_constraint:
     if (ctx.result.code == PARSE_SYNTAX_ERROR)
         return false; // There was a syntax error written already to the context...
@@ -146,45 +146,45 @@ err_expect_column_def_or_constraint:
         create_syntax_error_marker(ctx, estr);
         return false;
     }
-    expect_table_list_close:
-        // We get here after successfully parsing the <table element list>
-        // column/constraint definitions and are now expecting the closing
-        // RPAREN to indicate the end of the <table element list>
-        cur_tok = lex.current_token;
-        cur_sym = cur_tok.symbol;
-        switch (cur_sym) {
-            case SYMBOL_RPAREN:
-                cur_tok = lex.next();
-                goto statement_ending;
-            case SYMBOL_COMMA:
-                cur_tok = lex.next();
-                goto expect_table_list_element;
-            default:
-                goto err_expect_rparen_or_comma;
-        }
-    err_expect_rparen_or_comma:
-        expect_any_error(ctx, {SYMBOL_COMMA, SYMBOL_RPAREN});
-        return false;
-    statement_ending:
-        // We get here if we have already successfully processed the CREATE
-        // TABLE statement and are expecting EOS or SEMICOLON as the next
-        // non-comment token
-        cur_sym = cur_tok.symbol;
-        if (cur_sym == SYMBOL_SEMICOLON || cur_sym == SYMBOL_EOS)
-            goto push_statement;
-        expect_any_error(ctx, {SYMBOL_EOS, SYMBOL_SEMICOLON});
-        return false;
-    push_statement:
-        {
-            if (ctx.opts.disable_statement_construction)
-                return true;
-            identifier_t table_ident(ident);
-            auto stmt_p = std::make_unique<statements::create_table_t>(table_type, table_ident);
-            stmt_p->column_definitions = std::move(column_defs);
-            stmt_p->constraints = std::move(constraints);
-            ctx.result.statements.emplace_back(std::move(stmt_p));
+expect_table_list_close:
+    // We get here after successfully parsing the <table element list>
+    // column/constraint definitions and are now expecting the closing
+    // RPAREN to indicate the end of the <table element list>
+    cur_tok = lex.current_token;
+    cur_sym = cur_tok.symbol;
+    switch (cur_sym) {
+        case SYMBOL_RPAREN:
+            cur_tok = lex.next();
+            goto statement_ending;
+        case SYMBOL_COMMA:
+            cur_tok = lex.next();
+            goto expect_table_list_element;
+        default:
+            goto err_expect_rparen_or_comma;
+    }
+err_expect_rparen_or_comma:
+    expect_any_error(ctx, {SYMBOL_COMMA, SYMBOL_RPAREN});
+    return false;
+statement_ending:
+    // We get here if we have already successfully processed the CREATE
+    // TABLE statement and are expecting EOS or SEMICOLON as the next
+    // non-comment token
+    cur_sym = cur_tok.symbol;
+    if (cur_sym == SYMBOL_SEMICOLON || cur_sym == SYMBOL_EOS)
+        goto push_statement;
+    expect_any_error(ctx, {SYMBOL_EOS, SYMBOL_SEMICOLON});
+    return false;
+push_statement:
+    {
+        if (ctx.opts.disable_statement_construction)
             return true;
-        }
+        identifier_t table_ident(ident);
+        auto stmt_p = std::make_unique<statements::create_table_t>(table_type, table_ident);
+        stmt_p->column_definitions = std::move(column_defs);
+        stmt_p->constraints = std::move(constraints);
+        ctx.result.statements.emplace_back(std::move(stmt_p));
+        return true;
+    }
 }
 
 } // namespace sqltoast


### PR DESCRIPTION
Just pulls out some reusable parsers from the large parse_references_constraint() function