### PR TITLE
implement support for foreign key constraints on table

### DIFF
--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -27,6 +27,14 @@ bool parse_constraint(
         token_t& cur_tok,
         std::vector<std::unique_ptr<constraint_t>>& constraints);
 
+// Returns true if a foreign key constraint can be parsed from the supplied
+// token iterator. If the function returns true, constraint_p will be filled
+// appropriately with attributes of the referential constraint
+bool parse_foreign_key_constraint(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::unique_ptr<constraint_t>& constraint_p);
+
 // Returns true if a column definition clause can be parsed from the supplied
 // token iterator. If the function returns true, column_defs will have a new
 // member (if ctx.options.disable_statement_construction is false

--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -53,15 +53,13 @@ bool parse_column_constraint(
         column_definition_t& column_def,
         std::vector<std::unique_ptr<constraint_t>>& constraints);
 
-// Returns true if a references column constraint can be parsed from the
-// supplied token iterator. If the function returns true, column_def will have
-// a new references_constraint_t added to its constraints member.
-bool parse_references_constraint(
+// Returns true if a references specification can be parsed from the
+// supplied token iterator. If the function returns true, constraint_p will be
+// a populated foreign_key_constraint_t
+bool parse_references_specification(
         parse_context_t& ctx,
         token_t& cur_tok,
-        column_definition_t& column_def,
-        std::unique_ptr<identifier_t>& constraint_name,
-        std::vector<std::unique_ptr<constraint_t>>& constraints);
+        std::unique_ptr<constraint_t>& constraint_p);
 
 // Returns true if one or more identifiers, delimited by commas, can be parsed
 // from the supplied token iterator. If the function returns true, identifiers


### PR DESCRIPTION
While we supported foreign key constraints when specified against a specific column definition in a CREATE TABLE, we did not support them when specified with a <referencing columns> clause against the table as a whole. This patch fixes that.