### PR TITLE
ensure tokenizers never pass end parse_position_t

### DIFF
--- a/src/parser/comment.cc
+++ b/src/parser/comment.cc
@@ -30,7 +30,9 @@ namespace sqltoast {
 // comments, because they are sometimes used to embed dialect-specific
 // triggers, are consumed as tokens.
 
-tokenize_result_t token_comment(parse_position_t cursor) {
+tokenize_result_t token_comment(
+        parse_position_t cursor,
+        const parse_position_t end) {
     parse_position_t start = cursor;
     if (*cursor != '/')
         return tokenize_result_t(TOKEN_NOT_FOUND);
@@ -43,7 +45,7 @@ tokenize_result_t token_comment(parse_position_t cursor) {
     // find the closing */ marker
     do {
         cursor++;
-        if (*cursor == '\0' || *(cursor + 1) == '\0') {
+        if (cursor == end || (cursor + 1) == end) {
             return tokenize_result_t(TOKEN_ERR_NO_CLOSING_DELIMITER, start, cursor);
         }
     } while (*cursor != '*' || *(cursor + 1) != '/');

--- a/src/parser/comment.h
+++ b/src/parser/comment.h
@@ -11,7 +11,9 @@
 
 namespace sqltoast {
 
-tokenize_result_t token_comment(parse_position_t cursor);
+tokenize_result_t token_comment(
+        parse_position_t cursor,
+        const parse_position_t end);
 
 } // namespace sqltoast
 

--- a/src/parser/error.cc
+++ b/src/parser/error.cc
@@ -18,9 +18,9 @@ namespace sqltoast {
 void create_syntax_error_marker(parse_context_t& ctx, std::stringstream& es) {
     lexer_t& lex = ctx.lexer;
     parse_position_t err_pos = lex.current_token.lexeme.start;
-    std::string original(lex.start_pos, lex.end_pos);
+    std::string original(lex.start, lex.end);
     std::string location(original);
-    auto start_pos = err_pos - lex.start_pos;
+    auto start_pos = err_pos - lex.start;
     for (auto cur = location.begin(); cur != location.end(); cur++) {
         auto loc_pos = cur - location.begin() + 1;
         if (loc_pos < start_pos) {

--- a/src/parser/identifier.cc
+++ b/src/parser/identifier.cc
@@ -24,7 +24,9 @@ namespace sqltoast {
 //
 // Note that whitespace will have been skipped already so that the character
 // pointed to by the parse context is guaranteed to be not whitespace.
-tokenize_result_t token_identifier(parse_position_t cursor) {
+tokenize_result_t token_identifier(
+        parse_position_t cursor,
+        const parse_position_t end) {
     parse_position_t start = cursor;
     escape_mode current_escape = ESCAPE_NONE;
 
@@ -50,26 +52,28 @@ tokenize_result_t token_identifier(parse_position_t cursor) {
     }
     if (current_escape != ESCAPE_NONE)
         // handle delimited identifiers...
-        return token_delimited_identifier(cursor, current_escape);
+        return token_delimited_identifier(cursor, end, current_escape);
 
     // If we're not a delimited identifier, then consume all non-space characters
     // until the end of the parse subject or the next whitespace character
-    while (! std::isspace(*cursor)
-            && *cursor != '\0'
+    while (cursor != end
+            && ! std::isspace(*cursor)
             && *cursor != ';'
             && *cursor != '('
             && *cursor != ')'
             && *cursor != ',')
         cursor++;
 
-    // if we went more than a single character, that's an
-    // identifier...
+    // if we went more than a single character, that's an identifier...
     if (start != cursor)
         return tokenize_result_t(SYMBOL_IDENTIFIER, start, cursor);
     return tokenize_result_t(TOKEN_NOT_FOUND);
 }
 
-tokenize_result_t token_delimited_identifier(parse_position_t cursor, escape_mode current_escape) {
+tokenize_result_t token_delimited_identifier(
+        parse_position_t cursor,
+        const parse_position_t end,
+        escape_mode current_escape) {
     parse_position_t start = cursor;
     char closer;
     switch (current_escape) {
@@ -87,7 +91,7 @@ tokenize_result_t token_delimited_identifier(parse_position_t cursor, escape_mod
             return tokenize_result_t(TOKEN_NOT_FOUND);
     }
     char c;
-    while (*cursor != '\0') {
+    while (cursor != end) {
         cursor++;
         c = *cursor;
         if (c == closer) {

--- a/src/parser/identifier.h
+++ b/src/parser/identifier.h
@@ -13,11 +13,16 @@ namespace sqltoast {
 
 // Returns true if an identifier (of any kind) can be parsed from the parse
 // context's cursor position
-tokenize_result_t token_identifier(parse_position_t cursor);
+tokenize_result_t token_identifier(
+        parse_position_t cursor,
+        const parse_position_t end);
 
 // Returns true if a delimited identifier can be parsed from the parse
 // context's cursor position.
-tokenize_result_t token_delimited_identifier(parse_position_t cursor, escape_mode current_escape);
+tokenize_result_t token_delimited_identifier(
+        parse_position_t cursor,
+        const parse_position_t end,
+        escape_mode current_escape);
 
 } // namespace sqltoast
 

--- a/src/parser/keyword.cc
+++ b/src/parser/keyword.cc
@@ -160,7 +160,9 @@ kw_jump_table_t kw_jump_tables::w = _init_kw_jump_table('w');
 kw_jump_table_t kw_jump_tables::y = _init_kw_jump_table('y');
 kw_jump_table_t kw_jump_tables::z = _init_kw_jump_table('z');
 
-tokenize_result_t token_keyword(parse_position_t cursor) {
+tokenize_result_t token_keyword(
+        parse_position_t cursor,
+        const parse_position_t end) {
     kw_jump_table_t* jump_tbl;
     switch (*cursor) {
         case 'a':
@@ -257,7 +259,7 @@ tokenize_result_t token_keyword(parse_position_t cursor) {
 
     parse_position_t start = cursor;
     // Find the next delimiter character...
-    while (std::isalnum(*cursor) || *cursor == '_')
+    while (cursor != end && std::isalnum(*cursor) || *cursor == '_')
         cursor++;
 
     const std::string lexeme(start, cursor);

--- a/src/parser/keyword.h
+++ b/src/parser/keyword.h
@@ -54,7 +54,9 @@ kw_jump_table_t _init_kw_jump_table(const char c);
 // Moves the supplied parse context's cursor to the next keyword found in the
 // context's input stream and sets the context's current symbol to the found
 // keyword symbol. Returns whether a keyword was found.
-tokenize_result_t token_keyword(parse_position_t cursor);
+tokenize_result_t token_keyword(
+        parse_position_t cursor,
+        const parse_position_t end);
 
 } // namespace sqltoast
 

--- a/src/parser/lexer.cc
+++ b/src/parser/lexer.cc
@@ -56,16 +56,16 @@ parse_position_t lexer_t::peek_from(parse_position_t cur, symbol_t* found) const
     // Advance the lexer's cursor over any whitespace or simple comments
     *found = SYMBOL_EOS;
     cur = skip(cur);
-    if (cur >= end_pos)
+    if (cur >= end)
         return cur;
 
     for (size_t x = 0; x < NUM_TOKENIZERS; x++) {
-        auto tok_res = tokenizers[x](cur);
+        auto tok_res = tokenizers[x](cur, end);
         if (tok_res.code == TOKEN_NOT_FOUND)
             continue;
         if (tok_res.code == TOKEN_FOUND) {
             *found = tok_res.token.symbol;
-            cur = tok_res.token.lexeme.end + 1;
+            cur = tok_res.token.lexeme.end;
             break;
         }
         // There was an error in tokenizing... return some error marker?
@@ -77,11 +77,11 @@ parse_position_t lexer_t::peek_from(parse_position_t cur, symbol_t* found) const
 symbol_t lexer_t::peek() const {
     parse_position_t cur = cursor;
     cur = skip(cur);
-    if (cur >= end_pos)
+    if (cur >= end)
         return SYMBOL_EOS;
 
     for (size_t x = 0; x < NUM_TOKENIZERS; x++) {
-        auto tok_res = tokenizers[x](cur);
+        auto tok_res = tokenizers[x](cur, end);
         if (tok_res.code == TOKEN_NOT_FOUND)
             continue;
         if (tok_res.code == TOKEN_FOUND)
@@ -96,16 +96,16 @@ symbol_t lexer_t::peek() const {
 token_t& lexer_t::next() {
     parse_position_t cur = cursor;
     cur = skip(cur);
-    if (cur >= end_pos) {
+    if (cur >= end) {
         current_token.symbol = SYMBOL_EOS;
-        current_token.lexeme.start = end_pos;
-        current_token.lexeme.end = end_pos;
+        current_token.lexeme.start = end;
+        current_token.lexeme.end = end;
         cursor = cur;
         return current_token;
     }
 
     for (size_t x = 0; x < NUM_TOKENIZERS; x++) {
-        auto tok_res = tokenizers[x](cur);
+        auto tok_res = tokenizers[x](cur, end);
         tokenize_result_code_t res_code = tok_res.code;
         if (res_code == TOKEN_NOT_FOUND)
             continue;

--- a/src/parser/lexer.cc
+++ b/src/parser/lexer.cc
@@ -18,11 +18,6 @@
 
 namespace sqltoast {
 
-void fill_lexeme(token_t& tok, lexeme_t& lexeme) {
-    lexeme.start = tok.lexeme.start;
-    lexeme.end = tok.lexeme.end;
-}
-
 parse_position_t skip_simple_comments(parse_position_t cursor) {
     parse_position_t start = cursor;
     if (*cursor != '-')

--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -78,7 +78,6 @@ parse_position_t skip(parse_position_t cur);
 // Advances the supplied cursor past any simple SQL comments and returns the
 // location of the cursor after skipping
 parse_position_t skip_simple_comments(parse_position_t cursor);
-void fill_lexeme(token_t& tok, lexeme_t& lexeme);
 
 } // namespace sqltoast
 

--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -25,13 +25,13 @@ enum escape_mode {
 };
 
 typedef struct lexer {
-    parse_position_t start_pos;
-    parse_position_t end_pos;
+    parse_position_t start;
+    parse_position_t end;
     parse_position_t cursor;
     token_t current_token;
     lexer(parse_input_t& subject) :
-        start_pos(subject.cbegin()),
-        end_pos(subject.cend()),
+        start(subject.cbegin()),
+        end(subject.cend()),
         cursor(subject.cbegin()),
         current_token(SYMBOL_SOS, subject.cbegin(), subject.cbegin())
     {}
@@ -60,17 +60,25 @@ typedef struct tokenize_result {
     tokenize_result(tokenize_result_code_t code) :
         code(code), token()
     {}
-    tokenize_result(tokenize_result_code_t errcode, parse_position_t start, parse_position_t end) :
+    tokenize_result(
+            tokenize_result_code_t errcode,
+            parse_position_t start,
+            parse_position_t end) :
         code(errcode),
         token(SYMBOL_ERROR, start, end)
     {}
-    tokenize_result(symbol_t sym, parse_position_t start, parse_position_t end) :
+    tokenize_result(
+            symbol_t sym,
+            parse_position_t start,
+            parse_position_t end) :
         code(TOKEN_FOUND),
         token(sym, start, end)
     {}
 } tokenize_result_t;
 
-typedef tokenize_result_t (*tokenize_func_t) (parse_position_t cursor);
+typedef tokenize_result_t (*tokenize_func_t) (
+        parse_position_t cursor,
+        const parse_position_t end);
 
 // Advances the supplied cursor past any whitespace and simple SQL comments and
 // returns the location of the cursor after skipping

--- a/src/parser/literal.cc
+++ b/src/parser/literal.cc
@@ -8,7 +8,9 @@
 
 namespace sqltoast {
 
-tokenize_result_t token_literal(parse_position_t cursor) {
+tokenize_result_t token_literal(
+        parse_position_t cursor,
+        const parse_position_t end) {
     parse_position_t start = cursor;
     symbol_t found_sym;
     bool found_sign = false; // set to true if + or - found
@@ -37,7 +39,7 @@ try_numeric:
         bool found_e = false;
         for (;;) {
             c = *cursor++;
-            if (*cursor == '\0') {
+            if (cursor == end) {
                 // Make sure if we got a single . that we followed it with at
                 // least one number...
                 if (*(cursor - 1) == '.')
@@ -112,7 +114,7 @@ try_numeric:
         }
     }
 push_literal:
-    return tokenize_result_t(found_sym, start, cursor - 1);
+    return tokenize_result_t(found_sym, start, cursor);
 not_found:
     return tokenize_result_t(TOKEN_NOT_FOUND);
 }

--- a/src/parser/literal.h
+++ b/src/parser/literal.h
@@ -14,7 +14,7 @@ namespace sqltoast {
 // Moves the supplied parse context's cursor to the next literal found in the
 // context's input stream and adds a token with type literal to the tokens
 // stack.Returns whether a literal was found.
-tokenize_result_t token_literal(parse_position_t cursor);
+tokenize_result_t token_literal(parse_position_t cursor, const parse_position_t end);
 
 } // namespace sqltoast
 

--- a/src/parser/parse.cc
+++ b/src/parser/parse.cc
@@ -31,7 +31,7 @@ parse_result_t parse(parse_input_t& subject, parse_options_t& opts) {
     lexer_t& lex = ctx.lexer;
     token_t& cur_tok = lex.current_token;
 
-    if (lex.cursor == lex.end_pos) {
+    if (lex.cursor == lex.end) {
         res.code = PARSE_INPUT_ERROR;
         res.error.assign("Nothing to parse.");
         return res;

--- a/src/parser/punctuator.cc
+++ b/src/parser/punctuator.cc
@@ -8,7 +8,9 @@
 
 namespace sqltoast {
 
-tokenize_result_t token_punctuator(parse_position_t cursor) {
+tokenize_result_t token_punctuator(
+        parse_position_t cursor,
+        const parse_position_t end) {
     const char c = *cursor;
     for (unsigned int x = 0; x < NUM_PUNCTUATORS; x++) {
         if (c == punctuator_char_map[x]) {

--- a/src/parser/punctuator.h
+++ b/src/parser/punctuator.h
@@ -41,7 +41,9 @@ static const symbol_t punctuator_symbol_map[9] = {
 // Moves the supplied parse context's cursor to the next punctuator found in the
 // context's input stream and sets the context's current symbol to the found
 // punctuator symbol. Returns whether a punctuator was found.
-tokenize_result_t token_punctuator(parse_position_t cursor);
+tokenize_result_t token_punctuator(
+        parse_position_t cursor,
+        const parse_position_t end);
 
 } // namespace sqltoast
 


### PR DESCRIPTION
Fixes issue #31 by ensuring that tokenizer functions never pass the end
position of the input stream.