### PR TITLE
Support IN (<subquery>) predicates

### DIFF
--- a/include/predicate.h
+++ b/include/predicate.h
@@ -107,13 +107,18 @@ typedef struct in_values_predicate : boolean_term_t {
 
 std::ostream& operator<< (std::ostream& out, const in_values_predicate_t& pred);
 
+typedef struct statement statement_t;
 typedef struct in_subquery_predicate : boolean_term_t {
     std::unique_ptr<row_value_constructor_t> left;
+    // Guaranteed to always be static_castable to a select_t
+    std::unique_ptr<statement_t> subquery;
     in_subquery_predicate(
             std::unique_ptr<row_value_constructor_t>& left,
+            std::unique_ptr<statement_t>& subq,
             bool reverse_op) :
         boolean_term_t(COMP_OP_IN_SUBQUERY, reverse_op),
-        left(std::move(left))
+        left(std::move(left)),
+        subquery(std::move(subq))
     {}
 } in_subquery_predicate_t;
 

--- a/src/parser/parse.cc
+++ b/src/parser/parse.cc
@@ -36,33 +36,23 @@ parse_result_t parse(parse_input_t& subject, parse_options_t& opts) {
         res.error.assign("Nothing to parse.");
         return res;
     }
+    cur_tok = lex.next();
 
     while (res.code == PARSE_OK) {
-        cur_tok = lex.next();
         if (cur_tok.symbol == SYMBOL_EOS)
             break;
+        if (cur_tok.symbol == SYMBOL_SEMICOLON) {
+            cur_tok = lex.next();
+            continue;
+        }
         if (cur_tok.is_keyword()) {
             parse_statement(ctx);
             continue;
         }
-        if (cur_tok.is_punctuator()) {
+        {
             std::stringstream estr;
-            estr << "Parse subject must either begin with a keyword or a "
-                    "comment, but found punctuation." << std::endl;
-            create_syntax_error_marker(ctx, estr);
-            continue;
-        }
-        if (cur_tok.is_literal()) {
-            std::stringstream estr;
-            estr << "Parse subject must either begin with a keyword or a "
-                    "comment, but found literal." << std::endl;
-            create_syntax_error_marker(ctx, estr);
-            continue;
-        }
-        if (cur_tok.is_identifier()) {
-            std::stringstream estr;
-            estr << "Parse subject must either begin with a keyword or a "
-                    "comment, but found identifier." << std::endl;
+            estr << "SQL statements begin with a keyword and end with a "
+                    "semicolon, but found " << cur_tok << "." << std::endl;
             create_syntax_error_marker(ctx, estr);
             continue;
         }

--- a/src/parser/statements/select.cc
+++ b/src/parser/statements/select.cc
@@ -169,16 +169,22 @@ expect_where_condition:
 statement_ending:
     // We get here if we have already successfully processed the SELECT
     // statement and are expecting EOS or SEMICOLON as the next non-comment
-    // token
+    // token. Alternately, we can find an RPAREN, which would indicate we may
+    // be at the end of a valid subquery, which is also fine. We rely on the
+    // caller to check for the validity of an RPAREN in the current lexical
+    // context.
     cur_sym = cur_tok.symbol;
-    if (cur_sym == SYMBOL_SEMICOLON || cur_sym == SYMBOL_EOS)
+    if (cur_sym == SYMBOL_SEMICOLON ||
+            cur_sym == SYMBOL_EOS ||
+            cur_sym == SYMBOL_RPAREN)
         goto push_statement;
-    expect_any_error(ctx, {SYMBOL_EOS, SYMBOL_SEMICOLON});
+    expect_any_error(ctx, {SYMBOL_EOS, SYMBOL_SEMICOLON, SYMBOL_RPAREN});
     return false;
 push_statement:
     if (ctx.opts.disable_statement_construction)
         return true;
-    out = std::make_unique<select_t>(distinct, selected_columns, referenced_tables, where_condition);
+    out = std::make_unique<select_t>(
+            distinct, selected_columns, referenced_tables, where_condition);
     return true;
 }
 

--- a/src/predicate.cc
+++ b/src/predicate.cc
@@ -120,7 +120,7 @@ std::ostream& operator<< (std::ostream& out, const in_values_predicate_t& pred) 
 };
 
 std::ostream& operator<< (std::ostream& out, const in_subquery_predicate_t& pred) {
-    out << *pred.left << " IN <subquery>";
+    out << *pred.left << " IN " << *pred.subquery;
     return out;
 }
 


### PR DESCRIPTION
Modifies the parsing of IN () predicates to allow the parsing of
sub-SELECTs (subqueries).

Issue #30 

Need to clean up the output formatting for subqueries, but things are working swimmingly:

```
$ ./sqltoaster "
SELECT a, b FROM t1 WHERE a IN (
  SELECT a FROM t2 WHERE c = 4 AND d IN (
    SELECT f FROM t3
  )
)"
OK
statements[0]:
  <statement: SELECT
   selected columns: 
     0: a
     1: b
   referenced tables: 
     0: t1
   where conditions: 
     column-reference[a] IN <statement: SELECT
   selected columns: 
     0: a
   referenced tables: 
     0: t2
   where conditions: 
     column-reference[c] = literal[4] AND column-reference[d] IN <statement: SELECT
   selected columns: 
     0: f
   referenced tables: 
     0: t3>
>
>

(took 16262 nanoseconds)
```