### PR TITLE
Support GROUP BY clause for SELECT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ SET(LIBSQLTOAST_SOURCES
     src/identifier.cc
     src/constraint.cc
     src/column_definition.cc
-    src/derived_column.cc
+    src/column_reference.cc
     src/data_type.cc
     src/parser/column_definition.cc
     src/parser/data_type_descriptor.cc

--- a/include/column_reference.h
+++ b/include/column_reference.h
@@ -4,8 +4,8 @@
  * See the COPYING file in the root project directory for full text.
  */
 
-#ifndef SQLTOAST_DERIVED_COLUMN_H
-#define SQLTOAST_DERIVED_COLUMN_H
+#ifndef SQLTOAST_COLUMN_REFERENCE_H
+#define SQLTOAST_COLUMN_REFERENCE_H
 
 namespace sqltoast {
 
@@ -22,6 +22,19 @@ typedef struct derived_column {
 
 std::ostream& operator<< (std::ostream& out, const derived_column_t& dc);
 
+typedef struct grouping_column_reference {
+    lexeme_t column;
+    lexeme_t collation;
+    grouping_column_reference(lexeme_t& column) :
+        column(column)
+    {}
+    inline bool has_collation() const {
+        return collation.start != parse_position_t(0);
+    }
+} grouping_column_reference_t;
+
+std::ostream& operator<< (std::ostream& out, const grouping_column_reference_t& dc);
+
 } // namespace sqltoast
 
-#endif /* SQLTOAST_DERIVED_COLUMN_H */
+#endif /* SQLTOAST_COLUMN_REFERENCE_H */

--- a/include/sqltoast.h.in
+++ b/include/sqltoast.h.in
@@ -22,7 +22,7 @@
 #include "data_type.h"
 #include "constraint.h"
 #include "column_definition.h"
-#include "derived_column.h"
+#include "column_reference.h"
 #include "value.h"
 #include "predicate.h"
 #include "table_reference.h"

--- a/include/statement.h
+++ b/include/statement.h
@@ -106,16 +106,19 @@ typedef struct select_statement : statement_t {
     std::vector<derived_column_t> selected_columns;
     std::vector<table_reference_t> referenced_tables;
     std::unique_ptr<search_condition_t> where_condition;
+    std::vector<grouping_column_reference_t> group_by_columns;
     select_statement(
             bool distinct,
             std::vector<derived_column_t>& selected_cols,
             std::vector<table_reference_t>& ref_tables,
-            std::unique_ptr<search_condition_t>& where_cond) :
+            std::unique_ptr<search_condition_t>& where_cond,
+            std::vector<grouping_column_reference_t>& group_by_cols) :
         statement_t(STATEMENT_TYPE_SELECT),
         distinct(distinct),
         selected_columns(std::move(selected_cols)),
         referenced_tables(std::move(ref_tables)),
-        where_condition(std::move(where_cond))
+        where_condition(std::move(where_cond)),
+        group_by_columns(std::move(group_by_cols))
     {}
 } select_statement_t;
 

--- a/src/column_reference.cc
+++ b/src/column_reference.cc
@@ -9,10 +9,16 @@
 namespace sqltoast {
 
 std::ostream& operator<< (std::ostream& out, const derived_column_t& dc) {
-    out << std::string(dc.value.start, dc.value.end);
-    if (dc.has_alias()) {
-        out << " AS " << std::string(dc.alias.start, dc.alias.end);
-    }
+    out << dc.value;
+    if (dc.has_alias())
+        out << " AS " << dc.alias;
+    return out;
+}
+
+std::ostream& operator<< (std::ostream& out, const grouping_column_reference_t& gcr) {
+    out << gcr.column;
+    if (gcr.has_collation())
+        out << " COLLATE " << gcr.collation;
     return out;
 }
 

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -153,6 +153,13 @@ std::ostream& operator<< (std::ostream& out, const select_statement_t& stmt) {
         out << std::endl << "   where conditions: ";
         out << *stmt.where_condition;
     }
+    if (! stmt.group_by_columns.empty()) {
+        out << std::endl << "   group by: ";
+        x = 0;
+        for (const grouping_column_reference_t& gcr : stmt.group_by_columns) {
+            out << std::endl << "     " << x++ << ": " << gcr;
+        }
+    }
     out << ">" << std::endl;
 
     return out;


### PR DESCRIPTION
Adds support for the GROUP BY clause in a SELECT SQL statement. The
GROUP BY clause is a list of one or more <grouping column reference>
elements, which are an identifier (for the column) and an optional
collation for that column.

Issue #30