### PR TITLE
Support for HAVING clause

### DIFF
--- a/include/statement.h
+++ b/include/statement.h
@@ -107,18 +107,21 @@ typedef struct select_statement : statement_t {
     std::vector<table_reference_t> referenced_tables;
     std::unique_ptr<search_condition_t> where_condition;
     std::vector<grouping_column_reference_t> group_by_columns;
+    std::unique_ptr<search_condition_t> having_condition;
     select_statement(
             bool distinct,
             std::vector<derived_column_t>& selected_cols,
             std::vector<table_reference_t>& ref_tables,
             std::unique_ptr<search_condition_t>& where_cond,
-            std::vector<grouping_column_reference_t>& group_by_cols) :
+            std::vector<grouping_column_reference_t>& group_by_cols,
+            std::unique_ptr<search_condition_t>& having_cond) :
         statement_t(STATEMENT_TYPE_SELECT),
         distinct(distinct),
         selected_columns(std::move(selected_cols)),
         referenced_tables(std::move(ref_tables)),
         where_condition(std::move(where_cond)),
-        group_by_columns(std::move(group_by_cols))
+        group_by_columns(std::move(group_by_cols)),
+        having_condition(std::move(having_cond))
     {}
 } select_statement_t;
 

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -150,7 +150,7 @@ std::ostream& operator<< (std::ostream& out, const select_statement_t& stmt) {
         out << std::endl << "     " << x++ << ": " << tr;
     }
     if (stmt.where_condition) {
-        out << std::endl << "   where conditions: ";
+        out << std::endl << "   where: ";
         out << *stmt.where_condition;
     }
     if (! stmt.group_by_columns.empty()) {
@@ -159,6 +159,10 @@ std::ostream& operator<< (std::ostream& out, const select_statement_t& stmt) {
         for (const grouping_column_reference_t& gcr : stmt.group_by_columns) {
             out << std::endl << "     " << x++ << ": " << gcr;
         }
+    }
+    if (stmt.having_condition) {
+        out << std::endl << "   having: ";
+        out << *stmt.having_condition;
     }
     out << ">" << std::endl;
 


### PR DESCRIPTION
Adds support for the HAVING clause of a SELECT statement.

Also fixes an issue where both the WHERE and GROUP BY clauses were mutually exclusive in the parse_select() function.

Issue #30