### PR TITLE
Adds a simple test framework

### DIFF
--- a/src/sqltoaster.cc
+++ b/src/sqltoaster.cc
@@ -46,18 +46,18 @@ void usage(const char* prg_name) {
 int main (int argc, char *argv[])
 {
     std::string input;
-    bool disable_statement_construction = false;
+    bool disable_timer = false;
     switch (argc) {
         case 1:
             usage(argv[0]);
             return 1;
         case 3:
-            if (strcmp(argv[1], "--disable-statement-construction") != 0) {
+            if (strcmp(argv[1], "--disable-timer") != 0) {
                 cout << "Unknown argument: " << argv[1] << endl;
                 usage(argv[0]);
                 return 1;
             }
-            disable_statement_construction = true;
+            disable_timer = true;
             input.assign(argv[2]);
             break;
         case 2:
@@ -69,10 +69,7 @@ int main (int argc, char *argv[])
             return 1;
     }
 
-    sqltoast::parse_options_t opts = {
-        sqltoast::SQL_DIALECT_ANSI_1992,
-        disable_statement_construction
-    };
+    sqltoast::parse_options_t opts = {sqltoast::SQL_DIALECT_ANSI_1992, false};
     parser p(opts, input);
 
     auto dur = measure<std::chrono::nanoseconds>::execution(p);
@@ -91,6 +88,7 @@ int main (int argc, char *argv[])
         cout << "Syntax error." << endl;
         cout << p.res.error << endl;
     }
-    cout << "(took " << dur << " nanoseconds)" << endl;
+    if (! disable_timer)
+        cout << "(took " << dur << " nanoseconds)" << endl;
     return 0;
 }

--- a/tests/grammar/ansi-92/insert-default-values.test
+++ b/tests/grammar/ansi-92/insert-default-values.test
@@ -1,0 +1,7 @@
+>INSERT INTO t1 DEFAULT VALUES
+OK
+statements[0]:
+  <statement: INSERT
+   table name: t1
+   default columns: true
+   default values: true>

--- a/tests/grammar/runner.py
+++ b/tests/grammar/runner.py
@@ -1,0 +1,145 @@
+#! /usr/bin/python
+
+import argparse
+import difflib
+import os
+import subprocess
+import sys
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+RESULT_OK = 0
+RESULT_TEST_ERROR = 1
+RESULT_TEST_FAILURE = 1
+SQLTOASTER_BINARY = os.path.join(TEST_DIR, '..', '..', '_build', 'sqltoaster')
+
+
+def get_dialects():
+    """Returns a set of string dialect names for the supported grammar
+    tests."""
+    dialects = set()
+    for fname in os.listdir(TEST_DIR):
+        if os.path.isdir(os.path.join(TEST_DIR, fname)):
+            dialects.add(fname)
+    return dialects
+
+
+def get_test_names(args):
+    """Returns the list of filtered test names"""
+    if args.dialect is not None:
+        dialects = set(args.dialect)
+    else:
+        dialects = get_dialects()
+    test_names = []
+    for dialect in dialects:
+        dpath = os.path.join(TEST_DIR, dialect)
+        for fname in os.listdir(dpath):
+            if fname.endswith(".test"):
+                test_names.append("%s/%s" % (dialect, fname[:-5]))
+    return sorted(test_names)
+
+
+def run_test(test_name):
+    test_path = os.path.join(TEST_DIR, test_name + ".test")
+    input_blocks = []
+    output_blocks = []
+    input_block = []
+    output_block = []
+    with open(test_path, 'rb') as tfile:
+        line = tfile.readline().rstrip("\n")
+        while line:
+            if not line:
+                break;
+            if line.startswith("#"):
+                continue
+            if line.startswith('>'):
+                # Clear out previous output block...
+                if output_block:
+                    output_blocks.append("\n".join(output_block))
+                    output_block = []
+                input_block.append(line[1:])
+            else:
+                # Clear out previous input block...
+                if input_block:
+                    input_blocks.append("\n".join(input_block))
+                    input_block = []
+                output_block.append(line)
+            line = tfile.readline().rstrip("\n")
+    if output_block:
+        output_blocks.append("\n".join(output_block))
+
+    if len(input_blocks) != len(output_blocks):
+        msg = ("Error in test file %s: expected same amount of input to "
+               "output blocks but got %d input blocks and %d output blocks.")
+        msg = msg % (test_name, len(input_blocks), len(output_blocks))
+        return RESULT_TEST_ERROR, msg
+    for testno, iblock in enumerate(input_blocks):
+        expected = output_blocks[testno]
+        cmd_args = [SQLTOASTER_BINARY, '--disable-timer', iblock]
+        try:
+            actual = subprocess.check_output(cmd_args)
+        except subprocess.CalledProcessError as err:
+            msg = ("Failed to execute test number %d inside %s. Got: %s")
+            msg = msg % (testno, test_name, err)
+            return RESULT_TEST_ERROR, msg
+
+        actual = actual.rstrip("\n")
+
+        if actual != expected:
+            msg = "expected != actual\n"
+            diff = difflib.unified_diff(expected, actual,
+                                        fromfile="expected",
+                                        tofile="actual")
+            msg += "".join(list(diff))
+            return RESULT_TEST_FAILURE, msg
+
+    return RESULT_OK, None
+
+
+def parse_options():
+    """
+    Parse any command line options and environs defaults and return an options
+    object.
+    """
+    p = argparse.ArgumentParser(description="Run SQL grammar tests.")
+    p.add_argument("command", default="run", choices=['run', 'list'])
+    p.add_argument("--test-regex", "-r", default=None,
+                   help="(optional) regex pattern to filter tests to run")
+    p.add_argument("--dialect", choices=get_dialects(), default=None,
+                   help="(optional) Only run SQL grammar tests for the "
+                        "dialect specified. By default, all dialect tests "
+                        "are run")
+
+    return p.parse_args()
+
+
+def command_list(args):
+    """Lists tests that would meet any (optional) regex or dialect filters."""
+    test_names = get_test_names(args)
+    for tname in test_names:
+        sys.stdout.write("%s\n" % tname)
+
+
+def command_run(args):
+    """Runs tests that meet any (optional) regex or dialect filters."""
+    test_names = get_test_names(args)
+    for tname in test_names:
+        sys.stdout.write("Running %s ... " % tname)
+        res, err = run_test(tname)
+        if res == RESULT_OK:
+            sys.stdout.write("OK\n")
+        elif res == RESULT_TEST_ERROR:
+            sys.stdout.write("Error: %s\n" % err)
+        else:
+            sys.stdout.write("FAIL\n")
+            sys.stdout.write(err)
+
+
+COMMAND_CALLBACKS = {
+    'run': command_run,
+    'list': command_list,
+}
+
+
+if __name__ == "__main__":
+    args = parse_options()
+    COMMAND_CALLBACKS[args.command](args)


### PR DESCRIPTION
Adds a simple test framework for SQL grammar checking. Basically, the
test runner (written in Python) reads files in tests/grammar/$DIALECT
directories that end in .test. These test files contain an input to
sqltoaster, denoted with lines that begin with the ">" character,
followed by verbatim expected output from sqltoaster that describes the
parsed statement(s).

For example, here is the initial test file for the INSERT INTO statement
that uses the DEFAULT VALUES clause:

```
>INSERT INTO t1 DEFAULT VALUES
OK
statements[0]:
  <statement: INSERT
   table name: t1
   default columns: true
   default values: true>
```

The test runner simply throws the input SQL to sqltoaster and determines
if the output matches the expected output in the test file.

Issue #1