### PR TITLE
preparation work for JOIN parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ SET(LIBSQLTOAST_SOURCES
     src/parser/statements/select.cc
     src/parser/statements/update.cc
     src/parser/symbol.cc
+    src/parser/table_reference.cc
     src/parser/token.cc
     src/parser/value.cc
     src/parser/value_expression.cc

--- a/include/statement.h
+++ b/include/statement.h
@@ -105,14 +105,14 @@ std::ostream& operator<< (std::ostream& out, const drop_table_statement_t& stmt)
 typedef struct select_statement : statement_t {
     bool distinct;
     std::vector<derived_column_t> selected_columns;
-    std::vector<table_reference_t> referenced_tables;
+    std::vector<std::unique_ptr<table_reference_t>> referenced_tables;
     std::unique_ptr<search_condition_t> where_condition;
     std::vector<grouping_column_reference_t> group_by_columns;
     std::unique_ptr<search_condition_t> having_condition;
     select_statement(
             bool distinct,
             std::vector<derived_column_t>& selected_cols,
-            std::vector<table_reference_t>& ref_tables,
+            std::vector<std::unique_ptr<table_reference_t>>& ref_tables,
             std::unique_ptr<search_condition_t>& where_cond,
             std::vector<grouping_column_reference_t>& group_by_cols,
             std::unique_ptr<search_condition_t>& having_cond) :

--- a/include/table_reference.h
+++ b/include/table_reference.h
@@ -9,11 +9,25 @@
 
 namespace sqltoast {
 
+// A table reference is an object whose columns are referenced in the <select
+// list>, <group by>, <having>, <where> or <join condition> clauses of a
+// SEELECT statement. There are three types of table references. A table is
+// simply that: a table in the database that has been directly referenced in
+// the FROM clause. A joined table is a table reference that has been referred
+// to via a JOIN expression. And a derived table is a subquery in the FROM
+// clause.
+
+typedef enum table_reference_type_t {
+    TABLE_REFERENCE_TYPE_TABLE,
+    TABLE_REFERENCE_TYPE_DERIVED_TABLE,
+    TABLE_REFERENCE_TYPE_JOINED_TABLE
+} table_reference_type_t;
+
 typedef struct table_reference {
-    lexeme_t value;
+    table_reference_type_t type;
     lexeme_t alias;
-    table_reference(lexeme_t& value) :
-        value(value)
+    table_reference(table_reference_type_t type, lexeme_t& alias) :
+        type(type), alias(alias)
     {}
     inline bool has_alias() const {
         return alias.start != parse_position_t(0);
@@ -21,6 +35,16 @@ typedef struct table_reference {
 } table_reference_t;
 
 std::ostream& operator<< (std::ostream& out, const table_reference_t& tr);
+
+typedef struct table : table_reference_t {
+    lexeme_t table_name;
+    table(lexeme_t& table_name, lexeme_t& alias) :
+        table_reference_t(TABLE_REFERENCE_TYPE_TABLE, alias),
+        table_name(table_name)
+    {}
+} table_t;
+
+std::ostream& operator<< (std::ostream& out, const table_t& t);
 
 } // namespace sqltoast
 

--- a/include/table_reference.h
+++ b/include/table_reference.h
@@ -26,6 +26,9 @@ typedef enum table_reference_type_t {
 typedef struct table_reference {
     table_reference_type_t type;
     lexeme_t alias;
+    table_reference(table_reference_type_t type) :
+        type(type)
+    {}
     table_reference(table_reference_type_t type, lexeme_t& alias) :
         type(type), alias(alias)
     {}
@@ -45,6 +48,21 @@ typedef struct table : table_reference_t {
 } table_t;
 
 std::ostream& operator<< (std::ostream& out, const table_t& t);
+
+typedef struct derived_table : table_reference_t {
+    lexeme_t table_name;
+    // Will always be static_castable to select_statement_t
+    std::unique_ptr<statement_t> subquery;
+    derived_table(
+            lexeme_t& table_name,
+            std::unique_ptr<statement_t>& subquery) :
+        table_reference_t(TABLE_REFERENCE_TYPE_DERIVED_TABLE),
+        table_name(table_name),
+        subquery(std::move(subquery))
+    {}
+} derived_table_t;
+
+std::ostream& operator<< (std::ostream& out, const derived_table_t& dt);
 
 } // namespace sqltoast
 

--- a/src/parser/parse.h
+++ b/src/parser/parse.h
@@ -85,6 +85,13 @@ bool parse_update(
         token_t& cur_tok,
         std::unique_ptr<statement_t>& out);
 
+// Returns true if a table reference can be parsed. If true, the out argument
+// will contain a new pointer to a table_reference_t.
+bool parse_table_reference(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::unique_ptr<table_reference_t>& out);
+
 // Returns true if a search condition could be parsed. If true, the out
 // argument will have a new pointer to a search_condition_t added to it.
 bool parse_search_condition(

--- a/src/parser/table_reference.cc
+++ b/src/parser/table_reference.cc
@@ -1,0 +1,110 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#include "parser/error.h"
+#include "parser/parse.h"
+
+namespace sqltoast {
+
+// <table reference> ::=
+//     <table name> [ <correlation specification> ]
+//     | <derived table> <correlation specification>
+//     | <joined table>
+//
+// <correlation specification> ::=
+//     [ AS ] <correlation name>
+//     [ <left paren> <derived column list> <right paren> ]
+//
+// <derived column list> ::= <column name list>
+//
+// <derived table> ::= <table subquery>
+//
+// <table subquery> ::= <subquery>
+//
+// <joined table> ::=
+//     <cross join>
+//     | <qualified join>
+//     | <left paren> <joined table> <right paren>
+//
+// <cross join>    ::=
+//     <table reference> CROSS JOIN <table reference>
+//
+// <qualified join>    ::=
+//     <table reference> [ NATURAL ] [ <join type> ]
+//     JOIN <table reference> [ <join specification> ]
+//
+// <join type> ::=
+//     INNER
+//     | <outer join type> [ OUTER ]
+//     | UNION
+//
+// <outer join type> ::= LEFT | RIGHT | FULL
+//
+// <join specification> ::= <join condition> | <named columns join>
+//
+// <join condition>::= ON <search condition>
+//
+// <named columns join> ::=
+//     USING <left paren> <join column list> <right paren>
+//
+// <join column list> ::= <column name list>
+bool parse_table_reference(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::unique_ptr<table_reference_t>& out) {
+    lexer_t& lex = ctx.lexer;
+    symbol_t cur_sym = cur_tok.symbol;
+    lexeme_t table_name;
+    lexeme_t alias;
+    switch (cur_sym) {
+        case SYMBOL_LPAREN:
+            cur_tok = lex.next();
+            goto expect_derived_table;
+        case SYMBOL_IDENTIFIER:
+            table_name = cur_tok.lexeme;
+            cur_tok = lex.next();
+            goto optional_alias;
+        default:
+            return false;
+    }
+expect_derived_table:
+    cur_sym = cur_tok.symbol;
+    if (cur_sym != SYMBOL_RPAREN)
+        goto err_expect_rparen;
+    cur_tok = lex.next();
+    goto optional_alias;
+err_expect_rparen:
+    expect_error(ctx, SYMBOL_RPAREN);
+    return false;
+optional_alias:
+    // We get here after consuming an identifier, derived table specifier or
+    // joined table specifier. An alias can be provided for this table
+    // reference either by specifying an identifier immediately after the value
+    // expression or the keyword AS followed by the alias.
+    cur_sym = cur_tok.symbol;
+    if (cur_sym == SYMBOL_AS) {
+        cur_tok = lex.next();
+        cur_sym = cur_tok.symbol;
+        if (cur_sym != SYMBOL_IDENTIFIER)
+            goto err_expect_identifier;
+    }
+    if (cur_sym == SYMBOL_IDENTIFIER) {
+        alias = cur_tok.lexeme;
+        cur_tok = lex.next();
+    }
+    goto push_table_reference;
+err_expect_identifier:
+    expect_error(ctx, SYMBOL_IDENTIFIER);
+    return false;
+push_table_reference:
+    if (ctx.opts.disable_statement_construction)
+        return true;
+    if (table_name)
+        out = std::make_unique<table_t>(table_name, alias);
+    return true;
+}
+
+} // namespace sqltoast

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -152,8 +152,8 @@ std::ostream& operator<< (std::ostream& out, const select_statement_t& stmt) {
     }
     out << std::endl << "   referenced tables:";
     x = 0;
-    for (const table_reference_t& tr : stmt.referenced_tables) {
-        out << std::endl << "     " << x++ << ": " << tr;
+    for (const std::unique_ptr<table_reference_t>& tr : stmt.referenced_tables) {
+        out << std::endl << "     " << x++ << ": " << *tr;
     }
     if (stmt.where_condition) {
         out << std::endl << "   where:" << std::endl << "     ";

--- a/src/table_reference.cc
+++ b/src/table_reference.cc
@@ -9,10 +9,24 @@
 namespace sqltoast {
 
 std::ostream& operator<< (std::ostream& out, const table_reference_t& tr) {
-    out << std::string(tr.value.start, tr.value.end);
+    switch (tr.type) {
+        case TABLE_REFERENCE_TYPE_TABLE:
+            {
+                const table_t& t = static_cast<const table_t&>(tr);
+                out << t;
+            }
+            break;
+        default:
+            break;
+    }
     if (tr.has_alias()) {
         out << " AS " << std::string(tr.alias.start, tr.alias.end);
     }
+    return out;
+}
+
+std::ostream& operator<< (std::ostream& out, const table_t& t) {
+    out << std::string(t.table_name.start, t.table_name.end);
     return out;
 }
 

--- a/src/table_reference.cc
+++ b/src/table_reference.cc
@@ -16,6 +16,13 @@ std::ostream& operator<< (std::ostream& out, const table_reference_t& tr) {
                 out << t;
             }
             break;
+        case TABLE_REFERENCE_TYPE_DERIVED_TABLE:
+            {
+                const derived_table_t& dt =
+                    static_cast<const derived_table_t&>(tr);
+                out << dt;
+            }
+            break;
         default:
             break;
     }
@@ -27,6 +34,11 @@ std::ostream& operator<< (std::ostream& out, const table_reference_t& tr) {
 
 std::ostream& operator<< (std::ostream& out, const table_t& t) {
     out << std::string(t.table_name.start, t.table_name.end);
+    return out;
+}
+
+std::ostream& operator<< (std::ostream& out, const derived_table_t& dt) {
+    out << "<derived table> AS " << dt.table_name;
     return out;
 }
 

--- a/tests/grammar/ansi-92/table-references.test
+++ b/tests/grammar/ansi-92/table-references.test
@@ -1,0 +1,27 @@
+# Normal table with no alias
+>SELECT * FROM t1
+OK
+statements[0]:
+  <statement: SELECT
+   selected columns:
+     0: *
+   referenced tables:
+     0: t1>
+# Normal table with an alias using AS keyword
+>SELECT * FROM t1 AS t1_alias
+OK
+statements[0]:
+  <statement: SELECT
+   selected columns:
+     0: *
+   referenced tables:
+     0: t1 AS t1_alias>
+# Normal table with an alias NOT using AS keyword
+>SELECT * FROM t1 t1_alias
+OK
+statements[0]:
+  <statement: SELECT
+   selected columns:
+     0: *
+   referenced tables:
+     0: t1 AS t1_alias>

--- a/tests/grammar/ansi-92/table-references.test
+++ b/tests/grammar/ansi-92/table-references.test
@@ -25,3 +25,12 @@ statements[0]:
      0: *
    referenced tables:
      0: t1 AS t1_alias>
+# Derived table with name using AS keyword
+>SELECT * FROM (SELECT a, b FROM t1) AS t
+OK
+statements[0]:
+  <statement: SELECT
+   selected columns:
+     0: *
+   referenced tables:
+     0: <derived table> AS t>


### PR DESCRIPTION
Adds support for parsing different table reference types. Breaks out the parsing functions for table references into its own source file and breaks the `table_reference_t` struct into two subclasses representing a normal table and a derived table (subquery in the FROM clause)

Issue #58 