### PR TITLE
Complete ALTER TABLE support for ANSI-92

### DIFF
--- a/include/statement.h
+++ b/include/statement.h
@@ -156,6 +156,20 @@ typedef struct alter_column_action : alter_table_action_t {
 
 std::ostream& operator<< (std::ostream& out, const alter_column_action_t& action);
 
+typedef struct drop_column_action : alter_table_action_t {
+    lexeme_t column_name;
+    drop_behaviour_t drop_behaviour;
+    drop_column_action(
+            lexeme_t column_name,
+            drop_behaviour_t drop_behaviour) :
+        alter_table_action_t(ALTER_TABLE_ACTION_TYPE_DROP_COLUMN),
+        column_name(column_name),
+        drop_behaviour(drop_behaviour)
+    {}
+} drop_column_action_t;
+
+std::ostream& operator<< (std::ostream& out, const drop_column_action_t& action);
+
 typedef struct alter_table_statement : statement_t {
     lexeme_t table_name;
     std::unique_ptr<alter_table_action_t> action;

--- a/include/statement.h
+++ b/include/statement.h
@@ -130,6 +130,32 @@ typedef struct add_column_action : alter_table_action_t {
 
 std::ostream& operator<< (std::ostream& out, const add_column_action_t& action);
 
+typedef enum alter_column_action_type {
+    ALTER_COLUMN_ACTION_TYPE_SET_DEFAULT,
+    ALTER_COLUMN_ACTION_TYPE_DROP_DEFAULT
+} alter_column_action_type_t;
+
+typedef struct alter_column_action : alter_table_action_t {
+    alter_column_action_type_t alter_column_action_type;
+    lexeme_t column_name;
+    std::unique_ptr<default_descriptor_t> default_descriptor;
+    alter_column_action(lexeme_t column_name) :
+        alter_table_action_t(ALTER_TABLE_ACTION_TYPE_ALTER_COLUMN),
+        alter_column_action_type(ALTER_COLUMN_ACTION_TYPE_DROP_DEFAULT),
+        column_name(column_name)
+    {}
+    alter_column_action(
+            lexeme_t column_name,
+            std::unique_ptr<default_descriptor_t>& default_descriptor) :
+        alter_table_action_t(ALTER_TABLE_ACTION_TYPE_ALTER_COLUMN),
+        alter_column_action_type(ALTER_COLUMN_ACTION_TYPE_SET_DEFAULT),
+        column_name(column_name),
+        default_descriptor(std::move(default_descriptor))
+    {}
+} alter_column_action_t;
+
+std::ostream& operator<< (std::ostream& out, const alter_column_action_t& action);
+
 typedef struct alter_table_statement : statement_t {
     lexeme_t table_name;
     std::unique_ptr<alter_table_action_t> action;

--- a/include/statement.h
+++ b/include/statement.h
@@ -180,6 +180,20 @@ typedef struct add_constraint_action : alter_table_action_t {
 
 std::ostream& operator<< (std::ostream& out, const add_constraint_action_t& action);
 
+typedef struct drop_constraint_action : alter_table_action_t {
+    lexeme_t constraint_name;
+    drop_behaviour_t drop_behaviour;
+    drop_constraint_action(
+            lexeme_t constraint_name,
+            drop_behaviour_t drop_behaviour) :
+        alter_table_action_t(ALTER_TABLE_ACTION_TYPE_DROP_CONSTRAINT),
+        constraint_name(constraint_name),
+        drop_behaviour(drop_behaviour)
+    {}
+} drop_constraint_action_t;
+
+std::ostream& operator<< (std::ostream& out, const drop_column_action_t& action);
+
 typedef struct alter_table_statement : statement_t {
     lexeme_t table_name;
     std::unique_ptr<alter_table_action_t> action;

--- a/include/statement.h
+++ b/include/statement.h
@@ -107,8 +107,8 @@ typedef enum alter_table_action_type {
     ALTER_TABLE_ACTION_TYPE_ADD_COLUMN,
     ALTER_TABLE_ACTION_TYPE_ALTER_COLUMN,
     ALTER_TABLE_ACTION_TYPE_DROP_COLUMN,
-    ALTER_TABLE_ACTION_TYPE_ADD_TABLE_CONSTRAINT,
-    ALTER_TABLE_ACTION_TYPE_DROP_TABLE_CONSTRAINT
+    ALTER_TABLE_ACTION_TYPE_ADD_CONSTRAINT,
+    ALTER_TABLE_ACTION_TYPE_DROP_CONSTRAINT
 } alter_table_action_type_t;
 
 typedef struct alter_table_action {
@@ -169,6 +169,16 @@ typedef struct drop_column_action : alter_table_action_t {
 } drop_column_action_t;
 
 std::ostream& operator<< (std::ostream& out, const drop_column_action_t& action);
+
+typedef struct add_constraint_action : alter_table_action_t {
+    std::unique_ptr<constraint_t> constraint;
+    add_constraint_action(std::unique_ptr<constraint_t>& constraint) :
+        alter_table_action_t(ALTER_TABLE_ACTION_TYPE_ADD_CONSTRAINT),
+        constraint(std::move(constraint))
+    {}
+} add_constraint_action_t;
+
+std::ostream& operator<< (std::ostream& out, const add_constraint_action_t& action);
 
 typedef struct alter_table_statement : statement_t {
     lexeme_t table_name;

--- a/src/constraint.cc
+++ b/src/constraint.cc
@@ -88,7 +88,7 @@ std::ostream& operator<< (std::ostream& out, const foreign_key_constraint_t& con
         size_t num_referenced_columns = constraint.referenced_columns.size();
         out << ") REFERENCES " << constraint.referenced_table;
         if (num_referenced_columns > 0) {
-            out << "(";
+            out << " (";
             x = 0;
             for (const lexeme_t& col_name : constraint.referenced_columns) {
                 out << col_name;

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -163,6 +163,15 @@ std::ostream& operator<< (std::ostream& out, const alter_column_action_t& action
     return out;
 }
 
+std::ostream& operator<< (std::ostream& out, const drop_column_action_t& action) {
+    out << "DROP COLUMN " << action.column_name;
+    if (action.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
+        out << " CASCADE";
+    else
+        out << " RESTRICT";
+    return out;
+}
+
 std::ostream& operator<< (std::ostream& out, const alter_table_action_t& action) {
     switch (action.type) {
         case ALTER_TABLE_ACTION_TYPE_ADD_COLUMN:
@@ -180,7 +189,11 @@ std::ostream& operator<< (std::ostream& out, const alter_table_action_t& action)
             }
             break;
         case ALTER_TABLE_ACTION_TYPE_DROP_COLUMN:
-            out << "DROP COLUMN";
+            {
+                const drop_column_action_t& sub =
+                    static_cast<const drop_column_action_t&>(action);
+                out << sub;
+            }
             break;
         case ALTER_TABLE_ACTION_TYPE_ADD_TABLE_CONSTRAINT:
             out << "ADD CONSTRAINT";

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -153,6 +153,16 @@ std::ostream& operator<< (std::ostream& out, const add_column_action_t& action) 
     return out;
 }
 
+std::ostream& operator<< (std::ostream& out, const alter_column_action_t& action) {
+    if (action.alter_column_action_type == ALTER_COLUMN_ACTION_TYPE_SET_DEFAULT)
+        out << "ALTER COLUMN " << action.column_name
+            << " SET " << *action.default_descriptor;
+    else
+        out << "ALTER COLUMN " << action.column_name
+            << " DROP DEFAULT";
+    return out;
+}
+
 std::ostream& operator<< (std::ostream& out, const alter_table_action_t& action) {
     switch (action.type) {
         case ALTER_TABLE_ACTION_TYPE_ADD_COLUMN:
@@ -163,7 +173,11 @@ std::ostream& operator<< (std::ostream& out, const alter_table_action_t& action)
             }
             break;
         case ALTER_TABLE_ACTION_TYPE_ALTER_COLUMN:
-            out << "ALTER COLUMN";
+            {
+                const alter_column_action_t& sub =
+                    static_cast<const alter_column_action_t&>(action);
+                out << sub;
+            }
             break;
         case ALTER_TABLE_ACTION_TYPE_DROP_COLUMN:
             out << "DROP COLUMN";

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -172,6 +172,11 @@ std::ostream& operator<< (std::ostream& out, const drop_column_action_t& action)
     return out;
 }
 
+std::ostream& operator<< (std::ostream& out, const add_constraint_action_t& action) {
+    out << "ADD " << *action.constraint;
+    return out;
+}
+
 std::ostream& operator<< (std::ostream& out, const alter_table_action_t& action) {
     switch (action.type) {
         case ALTER_TABLE_ACTION_TYPE_ADD_COLUMN:
@@ -195,10 +200,14 @@ std::ostream& operator<< (std::ostream& out, const alter_table_action_t& action)
                 out << sub;
             }
             break;
-        case ALTER_TABLE_ACTION_TYPE_ADD_TABLE_CONSTRAINT:
-            out << "ADD CONSTRAINT";
+        case ALTER_TABLE_ACTION_TYPE_ADD_CONSTRAINT:
+            {
+                const add_constraint_action_t& sub =
+                    static_cast<const add_constraint_action_t&>(action);
+                out << sub;
+            }
             break;
-        case ALTER_TABLE_ACTION_TYPE_DROP_TABLE_CONSTRAINT:
+        case ALTER_TABLE_ACTION_TYPE_DROP_CONSTRAINT:
             out << "DROP CONSTRAINT";
             break;
     }

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -177,6 +177,15 @@ std::ostream& operator<< (std::ostream& out, const add_constraint_action_t& acti
     return out;
 }
 
+std::ostream& operator<< (std::ostream& out, const drop_constraint_action_t& action) {
+    out << "DROP CONSTRAINT " << action.constraint_name;
+    if (action.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
+        out << " CASCADE";
+    else
+        out << " RESTRICT";
+    return out;
+}
+
 std::ostream& operator<< (std::ostream& out, const alter_table_action_t& action) {
     switch (action.type) {
         case ALTER_TABLE_ACTION_TYPE_ADD_COLUMN:
@@ -208,7 +217,11 @@ std::ostream& operator<< (std::ostream& out, const alter_table_action_t& action)
             }
             break;
         case ALTER_TABLE_ACTION_TYPE_DROP_CONSTRAINT:
-            out << "DROP CONSTRAINT";
+            {
+                const drop_constraint_action_t& sub =
+                    static_cast<const drop_constraint_action_t&>(action);
+                out << sub;
+            }
             break;
     }
     return out;

--- a/tests/grammar/ansi-92/alter-table.test
+++ b/tests/grammar/ansi-92/alter-table.test
@@ -17,3 +17,31 @@ statements[0]:
   <statement: ALTER TABLE
    table name: t1
    action: ADD COLUMN b INT>
+# ADD COLUMN action without optional COLUMN keyword
+>ALTER TABLE t1 ADD b INT;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ADD COLUMN b INT>
+# ALTER COLUMN SET DEFAULT action
+>ALTER TABLE t1 ALTER COLUMN b SET DEFAULT NULL;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ALTER COLUMN b SET DEFAULT NULL>
+# ALTER COLUMN SET DEFAULT action optional COLUMN keyword
+>ALTER TABLE t1 ALTER b SET DEFAULT NULL;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ALTER COLUMN b SET DEFAULT NULL>
+# ALTER COLUMN DROP DEFAULT action
+>ALTER TABLE t1 ALTER COLUMN b DROP DEFAULT;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ALTER COLUMN b DROP DEFAULT>

--- a/tests/grammar/ansi-92/alter-table.test
+++ b/tests/grammar/ansi-92/alter-table.test
@@ -74,3 +74,45 @@ statements[0]:
   <statement: ALTER TABLE
    table name: t1
    action: DROP COLUMN b RESTRICT>
+# ADD CONSTRAINT action with UNIQUE constraint
+>ALTER TABLE t1 ADD UNIQUE (b, c);
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ADD UNIQUE (b,c)>
+# ADD CONSTRAINT action with UNIQUE constraint with constraint name
+>ALTER TABLE t1 ADD CONSTRAINT u_bc UNIQUE (b, c);
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ADD CONSTRAINT u_bc UNIQUE (b,c)>
+# ADD CONSTRAINT action with PRIMARY KEY constraint
+>ALTER TABLE t1 ADD PRIMARY KEY (b, c);
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ADD PRIMARY KEY (b,c)>
+# ADD CONSTRAINT action with PRIMARY KEY constraint with constraint name
+>ALTER TABLE t1 ADD CONSTRAINT pk PRIMARY KEY (b, c);
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ADD CONSTRAINT pk PRIMARY KEY (b,c)>
+# ADD CONSTRAINT action with FOREIGN KEY constraint
+>ALTER TABLE t1 ADD FOREIGN KEY (t2_id) REFERENCES t2 (id);
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ADD FOREIGN KEY (t2_id) REFERENCES t2 (id)>
+# ADD CONSTRAINT action with FOREIGN KEY constraint with constraint name
+>ALTER TABLE t1 ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id);
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id)>

--- a/tests/grammar/ansi-92/alter-table.test
+++ b/tests/grammar/ansi-92/alter-table.test
@@ -45,3 +45,32 @@ statements[0]:
   <statement: ALTER TABLE
    table name: t1
    action: ALTER COLUMN b DROP DEFAULT>
+# ALTER COLUMN DROP COLUMN action no drop behaviour
+>ALTER TABLE t1 DROP COLUMN b;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: DROP COLUMN b CASCADE>
+# ALTER COLUMN DROP COLUMN action no drop behaviour no optional COLUMN keyword
+>ALTER TABLE t1 DROP b;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: DROP COLUMN b CASCADE>
+# ALTER COLUMN DROP COLUMN action with explicit drop behaviour of default
+# CASCADE
+>ALTER TABLE t1 DROP COLUMN b CASCADE;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: DROP COLUMN b CASCADE>
+# ALTER COLUMN DROP COLUMN action with explicit drop behaviour of RESTRICT
+>ALTER TABLE t1 DROP COLUMN b RESTRICT;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: DROP COLUMN b RESTRICT>

--- a/tests/grammar/ansi-92/alter-table.test
+++ b/tests/grammar/ansi-92/alter-table.test
@@ -45,29 +45,28 @@ statements[0]:
   <statement: ALTER TABLE
    table name: t1
    action: ALTER COLUMN b DROP DEFAULT>
-# ALTER COLUMN DROP COLUMN action no drop behaviour
+# DROP COLUMN action no drop behaviour
 >ALTER TABLE t1 DROP COLUMN b;
 OK
 statements[0]:
   <statement: ALTER TABLE
    table name: t1
    action: DROP COLUMN b CASCADE>
-# ALTER COLUMN DROP COLUMN action no drop behaviour no optional COLUMN keyword
+# DROP COLUMN action no drop behaviour no optional COLUMN keyword
 >ALTER TABLE t1 DROP b;
 OK
 statements[0]:
   <statement: ALTER TABLE
    table name: t1
    action: DROP COLUMN b CASCADE>
-# ALTER COLUMN DROP COLUMN action with explicit drop behaviour of default
-# CASCADE
+# DROP COLUMN action with explicit drop behaviour of default CASCADE
 >ALTER TABLE t1 DROP COLUMN b CASCADE;
 OK
 statements[0]:
   <statement: ALTER TABLE
    table name: t1
    action: DROP COLUMN b CASCADE>
-# ALTER COLUMN DROP COLUMN action with explicit drop behaviour of RESTRICT
+# DROP COLUMN action with explicit drop behaviour of RESTRICT
 >ALTER TABLE t1 DROP COLUMN b RESTRICT;
 OK
 statements[0]:
@@ -116,3 +115,24 @@ statements[0]:
   <statement: ALTER TABLE
    table name: t1
    action: ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id)>
+# DROP CONSTRAINT action no drop behaviour
+>ALTER TABLE t1 DROP CONSTRAINT b;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: DROP CONSTRAINT b CASCADE>
+# DROP CONSTRAINT action with explicit drop behaviour of default CASCADE
+>ALTER TABLE t1 DROP CONSTRAINT b CASCADE;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: DROP CONSTRAINT b CASCADE>
+# DROP CONSTRAINT action with explicit drop behaviour of RESTRICT
+>ALTER TABLE t1 DROP CONSTRAINT b RESTRICT;
+OK
+statements[0]:
+  <statement: ALTER TABLE
+   table name: t1
+   action: DROP CONSTRAINT b RESTRICT>


### PR DESCRIPTION
Adds support for the `ALTER TABLE` actions:

* `ALTER TABLE ALTER COLUMN`
* `ALTER TABLE DROP COLUMN`
* `ALTER TABLE ADD CONSTRAINT`
* `ALTER TABLE DROP CONSTRAINT`

Closes Issue #54 