### PR TITLE
YAML printing - phase 2

### DIFF
--- a/sqltoaster/CMakeLists.txt
+++ b/sqltoaster/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(PROJECT_DESCRIPTION "A demonstration of the sqltoast library")
 
 SET(SQLTOASTER_SOURCES
     main.cc
+    printer.cc
     print/identifier.cc
     print/constraint.cc
     print/column_definition.cc
@@ -15,6 +16,7 @@ SET(SQLTOASTER_SOURCES
     print/table_reference.cc
     print/value.cc
     print/value_expression.cc
+    print/yaml/statement.cc
 )
 
 ADD_EXECUTABLE(sqltoaster ${SQLTOASTER_SOURCES})

--- a/sqltoaster/main.cc
+++ b/sqltoaster/main.cc
@@ -40,7 +40,7 @@ struct parser {
 };
 
 void usage(const char* prg_name) {
-    cout << "Usage: " << prg_name << " [--disable-statement-construction] <SQL>" << endl;
+    cout << "Usage: " << prg_name << " [--disable-timer] [--yaml] <SQL>" << endl;
     cout << " using libsqltoast version " <<
         SQLTOAST_VERSION_MAJOR << '.' <<
         SQLTOAST_VERSION_MINOR << endl;
@@ -50,36 +50,35 @@ int main (int argc, char *argv[])
 {
     std::string input;
     bool disable_timer = false;
-    switch (argc) {
-        case 1:
-            usage(argv[0]);
-            return 1;
-        case 3:
-            if (strcmp(argv[1], "--disable-timer") != 0) {
-                cout << "Unknown argument: " << argv[1] << endl;
-                usage(argv[0]);
-                return 1;
-            }
+    bool use_yaml = false;
+
+    for (int x = 1; x < argc; x++) {
+        if (strcmp(argv[x], "--disable-timer") == 0) {
             disable_timer = true;
-            input.assign(argv[2]);
-            break;
-        case 2:
-            input.assign(argv[1]);
-            break;
-        default:
-            cout << "Expected 1 or 2 arguments but got " << argc << endl;
-            usage(argv[0]);
-            return 1;
+            continue;
+        }
+        if (strcmp(argv[x], "--yaml") == 0) {
+            use_yaml = true;
+            continue;
+        }
+        input.assign(argv[x]);
+        break;
+    }
+    if (input.empty()) {
+        usage(argv[0]);
+        return 1;
     }
 
     sqltoast::parse_options_t opts = {sqltoast::SQL_DIALECT_ANSI_1992, false};
     parser p(opts, input);
 
     auto dur = measure<std::chrono::nanoseconds>::execution(p);
-    sqltoaster::printer ptr(p.res);
+    sqltoaster::printer ptr(p.res, cout);
+    if (use_yaml)
+        ptr.set_yaml(cout);
     if (p.res.code == sqltoast::PARSE_OK) {
         cout << "OK";
-        cout << ptr;
+        cout << ptr << std::endl;
     } else if (p.res.code == sqltoast::PARSE_INPUT_ERROR) {
         cout << "Input error: " << p.res.error << endl;
     } else {

--- a/sqltoaster/print/yaml/printers.h
+++ b/sqltoaster/print/yaml/printers.h
@@ -1,0 +1,129 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#ifndef SQLTOASTER_PRINT_YAML_PRINTERS_H
+#define SQLTOASTER_PRINT_YAML_PRINTERS_H
+
+#include "../../printer.h"
+
+using namespace sqltoast;
+
+namespace sqltoaster {
+
+/* DDL/definition elements  */
+void to_yaml(printer_t& ptr, std::ostream& out, const default_descriptor_t& column_def);
+void to_yaml(printer_t& ptr, std::ostream& out, const column_definition_t& column_def);
+void to_yaml(printer_t& ptr, std::ostream& out, const grouping_column_reference_t& dc);
+void to_yaml(printer_t& ptr, std::ostream& out, const constraint_t& constraint);
+void to_yaml(printer_t& ptr, std::ostream& out, const not_null_constraint_t& constraint);
+void to_yaml(printer_t& ptr, std::ostream& out, const unique_constraint_t& constraint);
+void to_yaml(printer_t& ptr, std::ostream& out, const foreign_key_constraint_t& constraint);
+void to_yaml(printer_t& ptr, std::ostream& out, const data_type_descriptor_t& dt);
+void to_yaml(printer_t& ptr, std::ostream& out, const char_string_t& cs);
+void to_yaml(printer_t& ptr, std::ostream& out, const bit_string_t& bs);
+void to_yaml(printer_t& ptr, std::ostream& out, const exact_numeric_t& num);
+void to_yaml(printer_t& ptr, std::ostream& out, const approximate_numeric_t& num);
+void to_yaml(printer_t& ptr, std::ostream& out, const datetime_t& dt);
+void to_yaml(printer_t& ptr, std::ostream& out, const interval_unit_t& unit);
+void to_yaml(printer_t& ptr, std::ostream& out, const interval_t& interval);
+void to_yaml(printer_t& ptr, std::ostream& out, const identifier_t& id);
+void to_yaml(printer_t& ptr, std::ostream& out, const derived_column_t& dc);
+
+/*  predicates */
+void to_yaml(printer_t& ptr, std::ostream& out, const predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const comp_op_t& op);
+void to_yaml(printer_t& ptr, std::ostream& out, const comp_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const between_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const like_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const null_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const in_values_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const in_subquery_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const quantified_comparison_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const exists_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const unique_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const match_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const overlaps_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const boolean_term_t& bt);
+void to_yaml(printer_t& ptr, std::ostream& out, const boolean_factor_t& bf);
+void to_yaml(printer_t& ptr, std::ostream& out, const boolean_primary_t& bp);
+void to_yaml(printer_t& ptr, std::ostream& out, const search_condition_t& sc);
+
+/*  statements */
+void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const create_schema_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_schema_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const create_table_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_table_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const alter_table_action_t& action);
+void to_yaml(printer_t& ptr, std::ostream& out, const add_column_action_t& action);
+void to_yaml(printer_t& ptr, std::ostream& out, const alter_column_action_t& action);
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_column_action_t& action);
+void to_yaml(printer_t& ptr, std::ostream& out, const add_constraint_action_t& action);
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_column_action_t& action);
+void to_yaml(printer_t& ptr, std::ostream& out, const alter_table_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const select_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const insert_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const insert_select_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const delete_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const update_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const create_view_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_view_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const grant_action_t& action);
+void to_yaml(printer_t& ptr, std::ostream& out, const grant_statement_t& stmt);
+
+/* query components */
+void to_yaml(printer_t& ptr, std::ostream& out, const table_reference_t& tr);
+void to_yaml(printer_t& ptr, std::ostream& out, const table_t& t);
+void to_yaml(printer_t& ptr, std::ostream& out, const derived_table_t& dt);
+void to_yaml(printer_t& ptr, std::ostream& out, const join_specification_t& js);
+void to_yaml(printer_t& ptr, std::ostream& out, const joined_table_t& jt);
+void to_yaml(printer_t& ptr, std::ostream& out, const value_expression_primary_t& vep);
+void to_yaml(printer_t& ptr, std::ostream& out, const unsigned_value_specification_t& uvs);
+void to_yaml(printer_t& ptr, std::ostream& out, const case_expression_t& ce);
+void to_yaml(printer_t& ptr, std::ostream& out, const coalesce_function_t& cf);
+void to_yaml(printer_t& ptr, std::ostream& out, const nullif_function_t& nf);
+void to_yaml(printer_t& ptr, std::ostream& out, const simple_case_expression_t& sce);
+void to_yaml(printer_t& ptr, std::ostream& out, const searched_case_expression_t& sce);
+void to_yaml(printer_t& ptr, std::ostream& out, const set_function_t& sf);
+void to_yaml(printer_t& ptr, std::ostream& out, const value_subexpression_t& uvs);
+void to_yaml(printer_t& ptr, std::ostream& out, const scalar_subquery_t& uvs);
+void to_yaml(printer_t& ptr, std::ostream& out, const numeric_primary_t& np);
+void to_yaml(printer_t& ptr, std::ostream& out, const numeric_value_t& nv);
+void to_yaml(printer_t& ptr, std::ostream& out, const numeric_function_t& nf);
+void to_yaml(printer_t& ptr, std::ostream& out, const position_expression_t& pe);
+void to_yaml(printer_t& ptr, std::ostream& out, const extract_expression_t& ee);
+void to_yaml(printer_t& ptr, std::ostream& out, const length_expression_t& le);
+void to_yaml(printer_t& ptr, std::ostream& out, const numeric_factor_t& nf);
+void to_yaml(printer_t& ptr, std::ostream& out, const numeric_term_t& nt);
+void to_yaml(printer_t& ptr, std::ostream& out, const string_function_t& sf);
+void to_yaml(printer_t& ptr, std::ostream& out, const substring_function_t& sf);
+void to_yaml(printer_t& ptr, std::ostream& out, const convert_function_t& cf);
+void to_yaml(printer_t& ptr, std::ostream& out, const translate_function_t& tf);
+void to_yaml(printer_t& ptr, std::ostream& out, const trim_function_t& tf);
+void to_yaml(printer_t& ptr, std::ostream& out, const character_primary_t& cp);
+void to_yaml(printer_t& ptr, std::ostream& out, const character_factor_t& cf);
+void to_yaml(printer_t& ptr, std::ostream& out, const datetime_primary_t& np);
+void to_yaml(printer_t& ptr, std::ostream& out, const datetime_value_t& nv);
+void to_yaml(printer_t& ptr, std::ostream& out, const current_datetime_function_t& df);
+void to_yaml(printer_t& ptr, std::ostream& out, const datetime_factor_t& factor);
+void to_yaml(printer_t& ptr, std::ostream& out, const datetime_term_t& term);
+void to_yaml(printer_t& ptr, std::ostream& out, const datetime_field_t& df);
+void to_yaml(printer_t& ptr, std::ostream& out, const interval_qualifier_t& iq);
+void to_yaml(printer_t& ptr, std::ostream& out, const interval_primary_t& primary);
+void to_yaml(printer_t& ptr, std::ostream& out, const interval_factor_t& factor);
+void to_yaml(printer_t& ptr, std::ostream& out, const interval_term_t& tern);
+void to_yaml(printer_t& ptr, std::ostream& out, const value_expression_t& ve);
+void to_yaml(printer_t& ptr, std::ostream& out, const numeric_expression_t& ne);
+void to_yaml(printer_t& ptr, std::ostream& out, const character_value_expression_t& ve);
+void to_yaml(printer_t& ptr, std::ostream& out, const datetime_value_expression_t& ve);
+void to_yaml(printer_t& ptr, std::ostream& out, const interval_value_expression_t& ve);
+void to_yaml(printer_t& ptr, std::ostream& out, const row_value_constructor_t& rvc);
+void to_yaml(printer_t& ptr, std::ostream& out, const row_value_constructor_element_t& rvce);
+void to_yaml(printer_t& ptr, std::ostream& out, const row_value_expression_t& rve);
+
+} // namespace sqltoast
+
+#endif /* SQLTOASTER_PRINT_YAML_PRINTERS_H */

--- a/sqltoaster/print/yaml/statement.cc
+++ b/sqltoaster/print/yaml/statement.cc
@@ -16,7 +16,7 @@ namespace sqltoaster {
 void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
     switch (stmt.type) {
         case STATEMENT_TYPE_CREATE_SCHEMA:
-            out << "type: CREATE_SCHEMA";
+            ptr.indent_noendl(out) << "type: CREATE_SCHEMA";
             {
                 const create_schema_statement_t& sub =
                     static_cast<const create_schema_statement_t&>(stmt);
@@ -24,7 +24,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_SCHEMA:
-            out << "type: DROP_SCHEMA";
+            ptr.indent_noendl(out) << "type: DROP_SCHEMA";
             {
                 const drop_schema_statement_t& sub =
                     static_cast<const drop_schema_statement_t&>(stmt);
@@ -32,7 +32,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_CREATE_TABLE:
-            out << "type: CREATE_TABLE";
+            ptr.indent_noendl(out) << "type: CREATE_TABLE";
             {
                 const create_table_statement_t& sub =
                     static_cast<const create_table_statement_t&>(stmt);
@@ -40,7 +40,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_TABLE:
-            out << "type: DROP_TABLE";
+            ptr.indent_noendl(out) << "type: DROP_TABLE";
             {
                 const drop_table_statement_t& sub =
                     static_cast<const drop_table_statement_t&>(stmt);
@@ -48,7 +48,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_ALTER_TABLE:
-            out << "type: ALTER_TABLE";
+            ptr.indent_noendl(out) << "type: ALTER_TABLE";
             {
                 const alter_table_statement_t& sub =
                     static_cast<const alter_table_statement_t&>(stmt);
@@ -56,7 +56,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_CREATE_VIEW:
-            out << "type: CREATE_VIEW";
+            ptr.indent_noendl(out) << "type: CREATE_VIEW";
             {
                 const create_view_statement_t& sub =
                     static_cast<const create_view_statement_t&>(stmt);
@@ -64,7 +64,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_VIEW:
-            out << "type: DROP_VIEW";
+            ptr.indent_noendl(out) << "type: DROP_VIEW";
             {
                 const drop_view_statement_t& sub =
                     static_cast<const drop_view_statement_t&>(stmt);
@@ -72,7 +72,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_SELECT:
-            out << "type: SELECT";
+            ptr.indent_noendl(out) << "type: SELECT";
             {
                 const select_statement_t& sub =
                     static_cast<const select_statement_t&>(stmt);
@@ -80,7 +80,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_INSERT:
-            out << "type: INSERT";
+            ptr.indent_noendl(out) << "type: INSERT";
             {
                 const insert_statement_t& sub =
                     static_cast<const insert_statement_t&>(stmt);
@@ -88,7 +88,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_INSERT_SELECT:
-            out << "type: INSERT_SELECT";
+            ptr.indent_noendl(out) << "type: INSERT_SELECT";
             {
                 const insert_select_statement_t& sub =
                     static_cast<const insert_select_statement_t&>(stmt);
@@ -96,27 +96,27 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DELETE:
-            out << "type: DELETE";
+            ptr.indent_noendl(out) << "type: DELETE";
             {
                 const delete_statement_t& sub = static_cast<const delete_statement_t&>(stmt);
                 to_yaml(ptr, out, sub);
             }
             break;
         case STATEMENT_TYPE_UPDATE:
-            out << "type: UPDATE";
+            ptr.indent_noendl(out) << "type: UPDATE";
             {
                 const update_statement_t& sub = static_cast<const update_statement_t&>(stmt);
                 to_yaml(ptr, out, sub);
             }
             break;
         case STATEMENT_TYPE_COMMIT:
-            out << "type: COMMIT";
+            ptr.indent_noendl(out) << "type: COMMIT";
             break;
         case STATEMENT_TYPE_ROLLBACK:
-            out << "type: ROLLBACK";
+            ptr.indent_noendl(out) << "type: ROLLBACK";
             break;
         case STATEMENT_TYPE_GRANT:
-            out << "type: GRANT";
+            ptr.indent_noendl(out) << "type: GRANT";
             {
                 const grant_statement_t& sub = static_cast<const grant_statement_t&>(stmt);
                 to_yaml(ptr, out, sub);
@@ -146,38 +146,40 @@ void to_yaml(printer_t& ptr, std::ostream& out, const drop_schema_statement_t& s
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const create_table_statement_t& stmt) {
-    out << "<statement: CREATE TABLE" << std::endl
-        << "    table name: " << stmt.table_name;
+    ptr.indent(out) << "table_name: " << stmt.table_name;
     if (stmt.table_type != TABLE_TYPE_NORMAL) {
-        out << std::endl << "    temporary: true (";
+        ptr.indent(out) << "temporary: true (";
         if (stmt.table_type == TABLE_TYPE_TEMPORARY_GLOBAL)
             out << "global)";
         else
             out << "local)";
     }
-    out << std::endl << "    column definitions:";
+    ptr.indent(out) << "column_definitions:";
+    ptr.indent_push(out);
     for (auto cdef_it = stmt.column_definitions.begin();
             cdef_it != stmt.column_definitions.end();
             cdef_it++) {
-        out << std::endl << "      " << *(*cdef_it);
+        ptr.indent(out) << "- "<< *(*cdef_it);
     }
+    ptr.indent_pop(out);
     if (stmt.constraints.size() > 0) {
-        out << std::endl << "    constraints:";
+        ptr.indent(out) << "constraints:";
+        ptr.indent_push(out);
         for (auto constraint_it = stmt.constraints.begin();
              constraint_it != stmt.constraints.end();
              constraint_it++) {
-            out << std::endl << "      " << *(*constraint_it);
+            ptr.indent(out) << "- " << *(*constraint_it);
         }
+        ptr.indent_pop(out);
     }
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const drop_table_statement_t& stmt) {
-    out << "<statement: DROP TABLE" << std::endl
-        << "   table name: " << stmt.table_name << std::endl;
+    ptr.indent(out) << "table_name: " << stmt.table_name;
     if (stmt.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
-       out << "   behaviour: CASCADE";
+       ptr.indent(out) << "drop_behaviour: CASCADE";
     else
-       out << "   behaviour: RESTRICT";
+       ptr.indent(out) << "drop_behaviour: RESTRICT";
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const add_column_action_t& action) {
@@ -260,61 +262,58 @@ void to_yaml(printer_t& ptr, std::ostream& out, const alter_table_statement_t& s
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const create_view_statement_t& stmt) {
-    out << "<statement: CREATE VIEW" << std::endl
-        << "   table name: " << stmt.table_name;
+    ptr.indent(out) << "table_name: " << stmt.table_name;
     if (! stmt.columns.empty()) {
-       out << std::endl << "   columns:";
-       size_t x = 0;
-       for (const auto& column : stmt.columns)
-           out << std::endl << "     " << x++ << ": " << column;
+        ptr.indent(out) << "column_definitions:";
+        ptr.indent_push(out);
+        for (const auto& column : stmt.columns)
+            ptr.indent(out) << "- "<< column;
+        ptr.indent_pop(out);
     }
     if (stmt.check_option != CHECK_OPTION_NONE) {
         if (stmt.check_option == CHECK_OPTION_LOCAL)
-            out << std::endl << "   check option: LOCAL";
+            ptr.indent(out) << "check_option: LOCAL";
         else
-            out << std::endl << "   check option: CASCADED";
+            ptr.indent(out) << "check_option: CASCADED";
     }
-    out << std::endl << "   query: " << *stmt.query << '>';
+    ptr.indent(out) << "query:" << std::endl;
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *stmt.query);
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const drop_view_statement_t& stmt) {
-    out << "<statement: DROP VIEW" << std::endl
-        << "   view name: " << stmt.table_name << std::endl;
+    ptr.indent(out) << "table_name: " << stmt.table_name;
     if (stmt.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
-       out << "   behaviour: CASCADE";
+       ptr.indent(out) << "drop_behaviour: CASCADE";
     else
-       out << "   behaviour: RESTRICT";
+       ptr.indent(out) << "drop_behaviour: RESTRICT";
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const select_statement_t& stmt) {
-    out << "<statement: SELECT";
     if (stmt.distinct)
-       out << std::endl << "   distinct: true";
-    out << std::endl << "   selected columns:";
-    size_t x = 0;
-    for (const derived_column_t& dc : stmt.selected_columns) {
-        out << std::endl << "     " << x++ << ": " << dc;
-    }
-    out << std::endl << "   referenced tables:";
-    x = 0;
-    for (const std::unique_ptr<table_reference_t>& tr : stmt.referenced_tables) {
-        out << std::endl << "     " << x++ << ": " << *tr;
-    }
-    if (stmt.where_condition) {
-        out << std::endl << "   where:" << std::endl << "     ";
-        out << *stmt.where_condition;
-    }
+       ptr.indent(out) << "distinct: true";
+    ptr.indent(out) << "selected_columns:";
+    ptr.indent_push(out);
+    for (const derived_column_t& dc : stmt.selected_columns)
+        ptr.indent(out) << "- " << dc;
+    ptr.indent_pop(out);
+    ptr.indent(out) << "referenced_tables:";
+    ptr.indent_push(out);
+    for (const std::unique_ptr<table_reference_t>& tr : stmt.referenced_tables)
+        ptr.indent(out) << "- " << *tr;
+    ptr.indent_pop(out);
+    if (stmt.where_condition)
+        ptr.indent(out) << "where:" << *stmt.where_condition;
     if (! stmt.group_by_columns.empty()) {
-        out << std::endl << "   group by:";
-        x = 0;
-        for (const grouping_column_reference_t& gcr : stmt.group_by_columns) {
-            out << std::endl << "     " << x++ << ": " << gcr;
-        }
+        ptr.indent(out) << "group_by:";
+        ptr.indent_push(out);
+        for (const grouping_column_reference_t& gcr : stmt.group_by_columns)
+            ptr.indent(out) << "- " << gcr;
+        ptr.indent_pop(out);
     }
-    if (stmt.having_condition) {
-        out << std::endl << "   having:" << std::endl << "     ";
-        out << *stmt.having_condition;
-    }
+    if (stmt.having_condition)
+        ptr.indent(out) << "having:" << *stmt.having_condition;
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const insert_statement_t& stmt) {

--- a/sqltoaster/print/yaml/statement.cc
+++ b/sqltoaster/print/yaml/statement.cc
@@ -16,7 +16,7 @@ namespace sqltoaster {
 void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
     switch (stmt.type) {
         case STATEMENT_TYPE_CREATE_SCHEMA:
-            out << "type: CREATE_SCHEMA" << std::endl;
+            out << "type: CREATE_SCHEMA";
             {
                 const create_schema_statement_t& sub =
                     static_cast<const create_schema_statement_t&>(stmt);
@@ -24,7 +24,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_SCHEMA:
-            out << "type: DROP_SCHEMA" << std::endl;
+            out << "type: DROP_SCHEMA";
             {
                 const drop_schema_statement_t& sub =
                     static_cast<const drop_schema_statement_t&>(stmt);
@@ -32,7 +32,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_CREATE_TABLE:
-            out << "type: CREATE_TABLE" << std::endl;
+            out << "type: CREATE_TABLE";
             {
                 const create_table_statement_t& sub =
                     static_cast<const create_table_statement_t&>(stmt);
@@ -40,7 +40,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_TABLE:
-            out << "type: DROP_TABLE" << std::endl;
+            out << "type: DROP_TABLE";
             {
                 const drop_table_statement_t& sub =
                     static_cast<const drop_table_statement_t&>(stmt);
@@ -48,7 +48,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_ALTER_TABLE:
-            out << "type: ALTER_TABLE" << std::endl;
+            out << "type: ALTER_TABLE";
             {
                 const alter_table_statement_t& sub =
                     static_cast<const alter_table_statement_t&>(stmt);
@@ -56,7 +56,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_CREATE_VIEW:
-            out << "type: CREATE_VIEW" << std::endl;
+            out << "type: CREATE_VIEW";
             {
                 const create_view_statement_t& sub =
                     static_cast<const create_view_statement_t&>(stmt);
@@ -64,7 +64,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_VIEW:
-            out << "type: DROP_VIEW" << std::endl;
+            out << "type: DROP_VIEW";
             {
                 const drop_view_statement_t& sub =
                     static_cast<const drop_view_statement_t&>(stmt);
@@ -72,7 +72,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_SELECT:
-            out << "type: SELECT" << std::endl;
+            out << "type: SELECT";
             {
                 const select_statement_t& sub =
                     static_cast<const select_statement_t&>(stmt);
@@ -80,7 +80,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_INSERT:
-            out << "type: INSERT" << std::endl;
+            out << "type: INSERT";
             {
                 const insert_statement_t& sub =
                     static_cast<const insert_statement_t&>(stmt);
@@ -88,7 +88,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_INSERT_SELECT:
-            out << "type: INSERT_SELECT" << std::endl;
+            out << "type: INSERT_SELECT";
             {
                 const insert_select_statement_t& sub =
                     static_cast<const insert_select_statement_t&>(stmt);
@@ -96,14 +96,14 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DELETE:
-            out << "type: DELETE" << std::endl;
+            out << "type: DELETE";
             {
                 const delete_statement_t& sub = static_cast<const delete_statement_t&>(stmt);
                 to_yaml(ptr, out, sub);
             }
             break;
         case STATEMENT_TYPE_UPDATE:
-            out << "type: UPDATE" << std::endl;
+            out << "type: UPDATE";
             {
                 const update_statement_t& sub = static_cast<const update_statement_t&>(stmt);
                 to_yaml(ptr, out, sub);
@@ -116,7 +116,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             out << "type: ROLLBACK";
             break;
         case STATEMENT_TYPE_GRANT:
-            out << "type: GRANT" << std::endl;
+            out << "type: GRANT";
             {
                 const grant_statement_t& sub = static_cast<const grant_statement_t&>(stmt);
                 to_yaml(ptr, out, sub);
@@ -130,22 +130,19 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
 void to_yaml(printer_t& ptr, std::ostream& out, const create_schema_statement_t& stmt) {
     ptr.indent(out) << "schema_name: " << stmt.schema_name;
     if (stmt.authorization_identifier) {
-       out << std::endl;
        ptr.indent(out) << "authorization_identifier: " << stmt.authorization_identifier;
     }
     if (stmt.default_charset) {
-       out << std::endl;
        ptr.indent(out) << "default_charset: " << stmt.default_charset;
     }
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const drop_schema_statement_t& stmt) {
-    out << "<statement: DROP SCHEMA" << std::endl
-        << "   schema name: " << stmt.schema_name << std::endl;
+    ptr.indent(out) << "schema_name: " << stmt.schema_name;
     if (stmt.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
-       out << "   behaviour: CASCADE";
+       ptr.indent(out) << "drop_behaviour: CASCADE";
     else
-       out << "   behaviour: RESTRICT";
+       ptr.indent(out) << "drop_behaviour: RESTRICT";
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const create_table_statement_t& stmt) {

--- a/sqltoaster/print/yaml/statement.cc
+++ b/sqltoaster/print/yaml/statement.cc
@@ -14,12 +14,8 @@ using namespace sqltoast;
 namespace sqltoaster {
 
 void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
-    ptr.indent_print(out);
-    out << "statement:" << std::endl;
-    ptr.indent_push(out);
     switch (stmt.type) {
         case STATEMENT_TYPE_CREATE_SCHEMA:
-            ptr.indent_print(out);
             out << "type: CREATE_SCHEMA" << std::endl;
             {
                 const create_schema_statement_t& sub =
@@ -28,7 +24,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_SCHEMA:
-            ptr.indent_print(out);
             out << "type: DROP_SCHEMA" << std::endl;
             {
                 const drop_schema_statement_t& sub =
@@ -37,7 +32,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_CREATE_TABLE:
-            ptr.indent_print(out);
             out << "type: CREATE_TABLE" << std::endl;
             {
                 const create_table_statement_t& sub =
@@ -46,7 +40,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_TABLE:
-            ptr.indent_print(out);
             out << "type: DROP_TABLE" << std::endl;
             {
                 const drop_table_statement_t& sub =
@@ -55,7 +48,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_ALTER_TABLE:
-            ptr.indent_print(out);
             out << "type: ALTER_TABLE" << std::endl;
             {
                 const alter_table_statement_t& sub =
@@ -64,7 +56,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_CREATE_VIEW:
-            ptr.indent_print(out);
             out << "type: CREATE_VIEW" << std::endl;
             {
                 const create_view_statement_t& sub =
@@ -73,7 +64,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DROP_VIEW:
-            ptr.indent_print(out);
             out << "type: DROP_VIEW" << std::endl;
             {
                 const drop_view_statement_t& sub =
@@ -82,7 +72,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_SELECT:
-            ptr.indent_print(out);
             out << "type: SELECT" << std::endl;
             {
                 const select_statement_t& sub =
@@ -91,7 +80,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_INSERT:
-            ptr.indent_print(out);
             out << "type: INSERT" << std::endl;
             {
                 const insert_statement_t& sub =
@@ -100,7 +88,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_INSERT_SELECT:
-            ptr.indent_print(out);
             out << "type: INSERT_SELECT" << std::endl;
             {
                 const insert_select_statement_t& sub =
@@ -109,7 +96,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_DELETE:
-            ptr.indent_print(out);
             out << "type: DELETE" << std::endl;
             {
                 const delete_statement_t& sub = static_cast<const delete_statement_t&>(stmt);
@@ -117,7 +103,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_UPDATE:
-            ptr.indent_print(out);
             out << "type: UPDATE" << std::endl;
             {
                 const update_statement_t& sub = static_cast<const update_statement_t&>(stmt);
@@ -125,15 +110,12 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
             }
             break;
         case STATEMENT_TYPE_COMMIT:
-            ptr.indent_print(out);
             out << "type: COMMIT";
             break;
         case STATEMENT_TYPE_ROLLBACK:
-            ptr.indent_print(out);
             out << "type: ROLLBACK";
             break;
         case STATEMENT_TYPE_GRANT:
-            ptr.indent_print(out);
             out << "type: GRANT" << std::endl;
             {
                 const grant_statement_t& sub = static_cast<const grant_statement_t&>(stmt);
@@ -143,21 +125,17 @@ void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
         default:
             break;
     }
-    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const create_schema_statement_t& stmt) {
-    ptr.indent_print(out);
-    out << "schema_name: " << stmt.schema_name;
+    ptr.indent(out) << "schema_name: " << stmt.schema_name;
     if (stmt.authorization_identifier) {
        out << std::endl;
-       ptr.indent_print(out);
-       out << "authorization_identifier: " << stmt.authorization_identifier;
+       ptr.indent(out) << "authorization_identifier: " << stmt.authorization_identifier;
     }
     if (stmt.default_charset) {
        out << std::endl;
-       ptr.indent_print(out);
-       out << "default_charset: " << stmt.default_charset;
+       ptr.indent(out) << "default_charset: " << stmt.default_charset;
     }
 }
 

--- a/sqltoaster/print/yaml/statement.cc
+++ b/sqltoaster/print/yaml/statement.cc
@@ -1,0 +1,483 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#include "sqltoast/sqltoast.h"
+
+#include "printers.h"
+#include "../printers.h"
+
+using namespace sqltoast;
+
+namespace sqltoaster {
+
+void to_yaml(printer_t& ptr, std::ostream& out, const statement_t& stmt) {
+    ptr.indent_print(out);
+    out << "statement:" << std::endl;
+    ptr.indent_push(out);
+    switch (stmt.type) {
+        case STATEMENT_TYPE_CREATE_SCHEMA:
+            ptr.indent_print(out);
+            out << "type: CREATE_SCHEMA" << std::endl;
+            {
+                const create_schema_statement_t& sub =
+                    static_cast<const create_schema_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_DROP_SCHEMA:
+            ptr.indent_print(out);
+            out << "type: DROP_SCHEMA" << std::endl;
+            {
+                const drop_schema_statement_t& sub =
+                    static_cast<const drop_schema_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_CREATE_TABLE:
+            ptr.indent_print(out);
+            out << "type: CREATE_TABLE" << std::endl;
+            {
+                const create_table_statement_t& sub =
+                    static_cast<const create_table_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_DROP_TABLE:
+            ptr.indent_print(out);
+            out << "type: DROP_TABLE" << std::endl;
+            {
+                const drop_table_statement_t& sub =
+                    static_cast<const drop_table_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_ALTER_TABLE:
+            ptr.indent_print(out);
+            out << "type: ALTER_TABLE" << std::endl;
+            {
+                const alter_table_statement_t& sub =
+                    static_cast<const alter_table_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_CREATE_VIEW:
+            ptr.indent_print(out);
+            out << "type: CREATE_VIEW" << std::endl;
+            {
+                const create_view_statement_t& sub =
+                    static_cast<const create_view_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_DROP_VIEW:
+            ptr.indent_print(out);
+            out << "type: DROP_VIEW" << std::endl;
+            {
+                const drop_view_statement_t& sub =
+                    static_cast<const drop_view_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_SELECT:
+            ptr.indent_print(out);
+            out << "type: SELECT" << std::endl;
+            {
+                const select_statement_t& sub =
+                    static_cast<const select_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_INSERT:
+            ptr.indent_print(out);
+            out << "type: INSERT" << std::endl;
+            {
+                const insert_statement_t& sub =
+                    static_cast<const insert_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_INSERT_SELECT:
+            ptr.indent_print(out);
+            out << "type: INSERT_SELECT" << std::endl;
+            {
+                const insert_select_statement_t& sub =
+                    static_cast<const insert_select_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_DELETE:
+            ptr.indent_print(out);
+            out << "type: DELETE" << std::endl;
+            {
+                const delete_statement_t& sub = static_cast<const delete_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_UPDATE:
+            ptr.indent_print(out);
+            out << "type: UPDATE" << std::endl;
+            {
+                const update_statement_t& sub = static_cast<const update_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case STATEMENT_TYPE_COMMIT:
+            ptr.indent_print(out);
+            out << "type: COMMIT";
+            break;
+        case STATEMENT_TYPE_ROLLBACK:
+            ptr.indent_print(out);
+            out << "type: ROLLBACK";
+            break;
+        case STATEMENT_TYPE_GRANT:
+            ptr.indent_print(out);
+            out << "type: GRANT" << std::endl;
+            {
+                const grant_statement_t& sub = static_cast<const grant_statement_t&>(stmt);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        default:
+            break;
+    }
+    ptr.indent_pop(out);
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const create_schema_statement_t& stmt) {
+    ptr.indent_print(out);
+    out << "schema_name: " << stmt.schema_name;
+    if (stmt.authorization_identifier) {
+       out << std::endl;
+       ptr.indent_print(out);
+       out << "authorization_identifier: " << stmt.authorization_identifier;
+    }
+    if (stmt.default_charset) {
+       out << std::endl;
+       ptr.indent_print(out);
+       out << "default_charset: " << stmt.default_charset;
+    }
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_schema_statement_t& stmt) {
+    out << "<statement: DROP SCHEMA" << std::endl
+        << "   schema name: " << stmt.schema_name << std::endl;
+    if (stmt.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
+       out << "   behaviour: CASCADE";
+    else
+       out << "   behaviour: RESTRICT";
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const create_table_statement_t& stmt) {
+    out << "<statement: CREATE TABLE" << std::endl
+        << "    table name: " << stmt.table_name;
+    if (stmt.table_type != TABLE_TYPE_NORMAL) {
+        out << std::endl << "    temporary: true (";
+        if (stmt.table_type == TABLE_TYPE_TEMPORARY_GLOBAL)
+            out << "global)";
+        else
+            out << "local)";
+    }
+    out << std::endl << "    column definitions:";
+    for (auto cdef_it = stmt.column_definitions.begin();
+            cdef_it != stmt.column_definitions.end();
+            cdef_it++) {
+        out << std::endl << "      " << *(*cdef_it);
+    }
+    if (stmt.constraints.size() > 0) {
+        out << std::endl << "    constraints:";
+        for (auto constraint_it = stmt.constraints.begin();
+             constraint_it != stmt.constraints.end();
+             constraint_it++) {
+            out << std::endl << "      " << *(*constraint_it);
+        }
+    }
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_table_statement_t& stmt) {
+    out << "<statement: DROP TABLE" << std::endl
+        << "   table name: " << stmt.table_name << std::endl;
+    if (stmt.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
+       out << "   behaviour: CASCADE";
+    else
+       out << "   behaviour: RESTRICT";
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const add_column_action_t& action) {
+    out << "ADD COLUMN " << *action.column_definition;
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const alter_column_action_t& action) {
+    if (action.alter_column_action_type == ALTER_COLUMN_ACTION_TYPE_SET_DEFAULT)
+        out << "ALTER COLUMN " << action.column_name
+            << " SET " << *action.default_descriptor;
+    else
+        out << "ALTER COLUMN " << action.column_name
+            << " DROP DEFAULT";
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_column_action_t& action) {
+    out << "DROP COLUMN " << action.column_name;
+    if (action.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
+        out << " CASCADE";
+    else
+        out << " RESTRICT";
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const add_constraint_action_t& action) {
+    out << "ADD" << *action.constraint;
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_constraint_action_t& action) {
+    out << "DROP CONSTRAINT " << action.constraint_name;
+    if (action.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
+        out << " CASCADE";
+    else
+        out << " RESTRICT";
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const alter_table_action_t& action) {
+    switch (action.type) {
+        case ALTER_TABLE_ACTION_TYPE_ADD_COLUMN:
+            {
+                const add_column_action_t& sub =
+                    static_cast<const add_column_action_t&>(action);
+                out << sub;
+            }
+            break;
+        case ALTER_TABLE_ACTION_TYPE_ALTER_COLUMN:
+            {
+                const alter_column_action_t& sub =
+                    static_cast<const alter_column_action_t&>(action);
+                out << sub;
+            }
+            break;
+        case ALTER_TABLE_ACTION_TYPE_DROP_COLUMN:
+            {
+                const drop_column_action_t& sub =
+                    static_cast<const drop_column_action_t&>(action);
+                out << sub;
+            }
+            break;
+        case ALTER_TABLE_ACTION_TYPE_ADD_CONSTRAINT:
+            {
+                const add_constraint_action_t& sub =
+                    static_cast<const add_constraint_action_t&>(action);
+                out << sub;
+            }
+            break;
+        case ALTER_TABLE_ACTION_TYPE_DROP_CONSTRAINT:
+            {
+                const drop_constraint_action_t& sub =
+                    static_cast<const drop_constraint_action_t&>(action);
+                out << sub;
+            }
+            break;
+    }
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const alter_table_statement_t& stmt) {
+    out << "<statement: ALTER TABLE" << std::endl
+        << "   table name: " << stmt.table_name << std::endl;
+    out << "   action: " << *stmt.action;
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const create_view_statement_t& stmt) {
+    out << "<statement: CREATE VIEW" << std::endl
+        << "   table name: " << stmt.table_name;
+    if (! stmt.columns.empty()) {
+       out << std::endl << "   columns:";
+       size_t x = 0;
+       for (const auto& column : stmt.columns)
+           out << std::endl << "     " << x++ << ": " << column;
+    }
+    if (stmt.check_option != CHECK_OPTION_NONE) {
+        if (stmt.check_option == CHECK_OPTION_LOCAL)
+            out << std::endl << "   check option: LOCAL";
+        else
+            out << std::endl << "   check option: CASCADED";
+    }
+    out << std::endl << "   query: " << *stmt.query << '>';
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const drop_view_statement_t& stmt) {
+    out << "<statement: DROP VIEW" << std::endl
+        << "   view name: " << stmt.table_name << std::endl;
+    if (stmt.drop_behaviour == DROP_BEHAVIOUR_CASCADE)
+       out << "   behaviour: CASCADE";
+    else
+       out << "   behaviour: RESTRICT";
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const select_statement_t& stmt) {
+    out << "<statement: SELECT";
+    if (stmt.distinct)
+       out << std::endl << "   distinct: true";
+    out << std::endl << "   selected columns:";
+    size_t x = 0;
+    for (const derived_column_t& dc : stmt.selected_columns) {
+        out << std::endl << "     " << x++ << ": " << dc;
+    }
+    out << std::endl << "   referenced tables:";
+    x = 0;
+    for (const std::unique_ptr<table_reference_t>& tr : stmt.referenced_tables) {
+        out << std::endl << "     " << x++ << ": " << *tr;
+    }
+    if (stmt.where_condition) {
+        out << std::endl << "   where:" << std::endl << "     ";
+        out << *stmt.where_condition;
+    }
+    if (! stmt.group_by_columns.empty()) {
+        out << std::endl << "   group by:";
+        x = 0;
+        for (const grouping_column_reference_t& gcr : stmt.group_by_columns) {
+            out << std::endl << "     " << x++ << ": " << gcr;
+        }
+    }
+    if (stmt.having_condition) {
+        out << std::endl << "   having:" << std::endl << "     ";
+        out << *stmt.having_condition;
+    }
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const insert_statement_t& stmt) {
+    out << "<statement: INSERT" << std::endl
+        << "   table name: " << stmt.table_name;
+
+    if (stmt.use_default_columns())
+        out << std::endl << "   default columns: true";
+    else {
+        out << std::endl << "   columns:";
+        size_t x = 0;
+        for (const lexeme_t& col : stmt.insert_columns) {
+            out << std::endl << "     " << x++ << ": " << col;
+        }
+    }
+    if (stmt.use_default_values())
+        out << std::endl << "   default values: true";
+    else {
+        size_t x = 0;
+        out << std::endl << "   values:";
+        for (const std::unique_ptr<row_value_constructor_t>& val : stmt.insert_values) {
+            out << std::endl << "     " << x++ << ": " << *val;
+        }
+    }
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const insert_select_statement_t& stmt) {
+    out << "<statement: INSERT" << std::endl
+        << "   table name: " << stmt.table_name;
+
+    if (stmt.use_default_columns())
+        out << std::endl << "   default columns: true";
+    else {
+        out << std::endl << "   columns:";
+        size_t x = 0;
+        for (const lexeme_t& col : stmt.insert_columns) {
+            out << std::endl << "     " << x++ << ": " << col;
+        }
+    }
+    out << std::endl << "   select:" << std::endl << "     " << *stmt.select;
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const delete_statement_t& stmt) {
+    out << "<statement: DELETE" << std::endl
+        << "   table name: " << stmt.table_name;
+
+    if (stmt.where_condition)
+        out << std::endl << "   where:" << std::endl << "     " << *stmt.where_condition;
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const update_statement_t& stmt) {
+    out << "<statement: UPDATE" << std::endl
+        << "   table name: " << stmt.table_name;
+
+    out << std::endl << "   set columns:";
+    for (const set_column_t& set_col : stmt.set_columns) {
+        out << std::endl << "     " << set_col.column_name << " = ";
+        if (set_col.type == SET_COLUMN_TYPE_NULL)
+            out << "NULL";
+        else if (set_col.type == SET_COLUMN_TYPE_DEFAULT)
+            out << "DEFAULT";
+        else
+            out << *set_col.value;
+    }
+
+    if (stmt.where_condition)
+        out << std::endl << "   where:" << std::endl << "     " << *stmt.where_condition;
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const grant_action_t& action) {
+    switch (action.type) {
+        case GRANT_ACTION_TYPE_SELECT:
+            out << "SELECT";
+            return;
+        case GRANT_ACTION_TYPE_DELETE:
+            out << "DELETE";
+            return;
+        case GRANT_ACTION_TYPE_USAGE:
+            out << "USAGE";
+            return;
+        case GRANT_ACTION_TYPE_INSERT:
+            out << "INSERT";
+            break;
+        case GRANT_ACTION_TYPE_UPDATE:
+            out << "UPDATE";
+            break;
+        case GRANT_ACTION_TYPE_REFERENCES:
+            out << "REFERENCES";
+            break;
+    }
+    const column_list_grant_action_t& cla =
+        static_cast<const column_list_grant_action_t&>(action);
+    if (cla.columns.empty())
+        return;
+    out << " (";
+    size_t x = 0;
+    for (const lexeme_t& col : cla.columns) {
+        if (x++ > 0)
+            out << ',';
+        out << col;
+    }
+    out << ')';
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const grant_statement_t& stmt) {
+    out << "<statement: GRANT" << std::endl
+        << "   on: ";
+    switch (stmt.object_type) {
+        case GRANT_OBJECT_TYPE_TABLE:
+            break;
+        case GRANT_OBJECT_TYPE_DOMAIN:
+            out << "DOMAIN ";
+            break;
+        case GRANT_OBJECT_TYPE_COLLATION:
+            out << "COLLATION ";
+            break;
+        case GRANT_OBJECT_TYPE_CHARACTER_SET:
+            out << "CHARACTER SET ";
+            break;
+        case GRANT_OBJECT_TYPE_TRANSLATION:
+            out << "TRANSLATION ";
+            break;
+    }
+    out << stmt.on << std::endl;
+    if (stmt.to_public())
+        out << "   to: PUBLIC" << std::endl;
+    else
+        out << "   to: " << stmt.to << std::endl;
+    if (stmt.with_grant_option)
+        out << "   with grant option: YES" << std::endl;
+    if (stmt.all_privileges())
+        out << "   privileges: ALL";
+    else {
+        out << "   privileges:";
+        size_t x = 0;
+        for (const std::unique_ptr<grant_action_t>& action : stmt.privileges)
+            out << std::endl << "     " << x++ << ": " << *action;
+    }
+}
+
+} // namespace sqltoast

--- a/sqltoaster/printer.cc
+++ b/sqltoaster/printer.cc
@@ -20,11 +20,14 @@ std::ostream& operator<< (std::ostream& out, printer_t& ptr) {
             out << "  " << *(*stmt_ptr_it);
         }
     } else {
+        out << std::endl << "statements:";
         for (auto stmt_ptr_it = ptr.res.statements.cbegin();
                 stmt_ptr_it != ptr.res.statements.cend();
                 stmt_ptr_it++) {
-            out << std::endl << "-";
+            out << std::endl << "- ";
+            ptr.indent_push(out);
             to_yaml(ptr, out, *(*stmt_ptr_it));
+            ptr.indent_pop(out);
         }
     }
     return out;

--- a/sqltoaster/printer.cc
+++ b/sqltoaster/printer.cc
@@ -1,0 +1,33 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#include "printer.h"
+#include "print/printers.h"
+#include "print/yaml/printers.h"
+
+namespace sqltoaster {
+
+std::ostream& operator<< (std::ostream& out, printer_t& ptr) {
+    if (! ptr.use_yaml(out)) {
+        unsigned int x = 0;
+        for (auto stmt_ptr_it = ptr.res.statements.cbegin();
+                stmt_ptr_it != ptr.res.statements.cend();
+                stmt_ptr_it++) {
+            out << std::endl << "statements[" << x++ << "]:" << std::endl;
+            out << "  " << *(*stmt_ptr_it);
+        }
+    } else {
+        for (auto stmt_ptr_it = ptr.res.statements.cbegin();
+                stmt_ptr_it != ptr.res.statements.cend();
+                stmt_ptr_it++) {
+            out << std::endl << "-";
+            to_yaml(ptr, out, *(*stmt_ptr_it));
+        }
+    }
+    return out;
+}
+
+} // namespace sqltoaster

--- a/sqltoaster/printer.h
+++ b/sqltoaster/printer.h
@@ -55,6 +55,13 @@ typedef struct printer {
             out << std::string(cur_indent * 2, ' ');
         return out;
     }
+    inline std::ostream& indent_noendl(std::ostream& out) {
+        int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
+        long cur_indent = out.iword(idx_indent);
+        if (cur_indent > 1)
+            out << std::string(cur_indent * 2, ' ');
+        return out;
+    }
 } printer_t;
 
 std::ostream& operator<< (std::ostream& out, printer_t& ptr);

--- a/sqltoaster/printer.h
+++ b/sqltoaster/printer.h
@@ -50,6 +50,7 @@ typedef struct printer {
     inline std::ostream& indent(std::ostream& out) {
         int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
         long cur_indent = out.iword(idx_indent);
+        out << std::endl;
         if (cur_indent > 0)
             out << std::string(cur_indent * 2, ' ');
         return out;

--- a/sqltoaster/printer.h
+++ b/sqltoaster/printer.h
@@ -47,11 +47,12 @@ typedef struct printer {
         long cur_indent = out.iword(idx_indent);
         out.iword(idx_indent) = --cur_indent;
     }
-    inline void indent_print(std::ostream& out) {
+    inline std::ostream& indent(std::ostream& out) {
         int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
         long cur_indent = out.iword(idx_indent);
         if (cur_indent > 0)
-            out << std::string(cur_indent, ' ');
+            out << std::string(cur_indent * 2, ' ');
+        return out;
     }
 } printer_t;
 

--- a/sqltoaster/printer.h
+++ b/sqltoaster/printer.h
@@ -23,29 +23,40 @@ const int INDENT_LEVEL_XALLOC_INDEX = 1;
 typedef struct printer {
     int iomanip_indexes[2];
     sqltoast::parse_result_t& res;
-    printer(sqltoast::parse_result_t& res) : res(res)
+    printer(sqltoast::parse_result_t& res, std::ostream& out) : res(res)
     {
         iomanip_indexes[OUTPUT_FORMAT_XALLOC_INDEX] = std::ios_base::xalloc();
         iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX] = std::ios_base::xalloc();
+        int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
+        out.iword(idx_indent) = 0;
+    }
+    inline void set_yaml(std::ostream& out) {
+        int idx_format = iomanip_indexes[OUTPUT_FORMAT_XALLOC_INDEX];
+        out.iword(idx_format) = OUTPUT_FORMAT_YAML;
     }
     inline bool use_yaml(std::ostream& out) const {
         return (out.iword(iomanip_indexes[OUTPUT_FORMAT_XALLOC_INDEX]) == OUTPUT_FORMAT_YAML);
     }
+    inline void indent_push(std::ostream& out) {
+        int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
+        long cur_indent = out.iword(idx_indent);
+        out.iword(idx_indent) = ++cur_indent;
+    }
+    inline void indent_pop(std::ostream& out) {
+        int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
+        long cur_indent = out.iword(idx_indent);
+        out.iword(idx_indent) = --cur_indent;
+    }
+    inline void indent_print(std::ostream& out) {
+        int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
+        long cur_indent = out.iword(idx_indent);
+        if (cur_indent > 0)
+            out << std::string(cur_indent, ' ');
+    }
 } printer_t;
 
-inline std::ostream& operator<< (std::ostream& out, const printer_t& ptr) {
-    if (! ptr.use_yaml(out)) {
-        unsigned int x = 0;
-        for (auto stmt_ptr_it = ptr.res.statements.cbegin();
-                stmt_ptr_it != ptr.res.statements.cend();
-                stmt_ptr_it++) {
-            out << std::endl << "statements[" << x++ << "]:" << std::endl;
-            out << "  " << *(*stmt_ptr_it) << std::endl;
-        }
-    }
-    return out;
-}
+std::ostream& operator<< (std::ostream& out, printer_t& ptr);
 
-} // namespace sqltoast
+} // namespace sqltoaster
 
 #endif /* SQLTOASTER_PRINTER_H */


### PR DESCRIPTION
Hit a savepoint in YAML printing. We're now able to output YAML for SQL statements, including statements that can be composed of multiple statements:

```
[jaypipes@uberbox _build]$ ./sqltoaster/sqltoaster --yaml "CREATE TABLE t1 (a INT NOT NULL)"
OK
statements:
- type: CREATE_TABLE
  table_name: t1
  column_definitions:
    - a INT NOT NULL
(took 21612 nanoseconds)
[jaypipes@uberbox _build]$ ./sqltoaster/sqltoaster --yaml "CREATE VIEW v1 AS SELECT * FROM t1"
OK
statements:
- type: CREATE_VIEW
  table_name: v1
  query:
    type: SELECT
    selected_columns:
      - *
    referenced_tables:
      - t1
(took 21196 nanoseconds)
```

Issue #104