### PR TITLE
Continued breakout of YAML-ized sqltoast struct printers

### DIFF
--- a/libsqltoast/src/print/value_expression.cc
+++ b/libsqltoast/src/print/value_expression.cc
@@ -38,14 +38,13 @@ std::ostream& operator<< (std::ostream& out, const row_value_constructor_t& rvc)
     return out;
 }
 
-
 std::ostream& operator<< (std::ostream& out, const row_value_constructor_element_t& rvce) {
     switch (rvce.rvc_element_type) {
         case RVC_ELEMENT_TYPE_DEFAULT:
-            out <<"DEFAULT";
+            out << "DEFAULT";
             break;
         case RVC_ELEMENT_TYPE_NULL:
-            out <<"NULL";
+            out << "NULL";
             break;
         case RVC_ELEMENT_TYPE_VALUE_EXPRESSION:
             {

--- a/sqltoaster/CMakeLists.txt
+++ b/sqltoaster/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(PROJECT_DESCRIPTION "A demonstration of the sqltoast library")
 SET(SQLTOASTER_SOURCES
     main.cc
     printer.cc
-    print/yaml/statement.cc
+    print/yaml.cc
 )
 
 ADD_EXECUTABLE(sqltoaster ${SQLTOASTER_SOURCES})

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -6,7 +6,7 @@
 
 #include <sqltoast/print.h>
 
-#include "printers.h"
+#include "yaml.h"
 
 namespace sqltoaster {
 namespace print {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -735,18 +735,36 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::comp_op_t& op) {
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::comp_predicate_t& pred) {
     to_yaml(ptr, out, pred.op);
-    ptr.indent(out) << "left: " << *pred.left;
-    ptr.indent(out) << "right: "<< *pred.right;
+    ptr.indent(out) << "left:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.left);
+    ptr.indent_pop(out);
+    ptr.indent(out) << "right:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.right);
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::between_predicate_t& pred) {
-    ptr.indent(out) << "left: " << *pred.left;
-    ptr.indent(out) << "comp_left: " << *pred.comp_left;
-    ptr.indent(out) << "comp_right: "<< *pred.comp_right;
+    ptr.indent(out) << "left:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.left);
+    ptr.indent_pop(out);
+    ptr.indent(out) << "comp_left:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.comp_left);
+    ptr.indent_pop(out);
+    ptr.indent(out) << "comp_right:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.comp_right);
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::like_predicate_t& pred) {
-    ptr.indent(out) << "match: " << *pred.match;
+    ptr.indent(out) << "match:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.match);
+    ptr.indent_pop(out);
     if (pred.reverse_op)
         ptr.indent(out) << "predicate_negate: true";
     ptr.indent(out) << "pattern: " << *pred.pattern;
@@ -760,7 +778,10 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::null_predicate_t
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_values_predicate_t& pred) {
-    ptr.indent(out) << "left: " << *pred.left;
+    ptr.indent(out) << "left:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.left);
+    ptr.indent_pop(out);
     if (pred.reverse_op)
         ptr.indent(out) << "predicate_negate: true";
     ptr.indent(out) << "values:";
@@ -771,7 +792,10 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_values_predic
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_subquery_predicate_t& pred) {
-    ptr.indent(out) << "left: " << *pred.left;
+    ptr.indent(out) << "left:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.left);
+    ptr.indent_pop(out);
     ptr.indent(out) << "query:";
     ptr.indent_push(out);
     to_yaml(ptr, out, *pred.subquery);
@@ -780,7 +804,10 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_subquery_pred
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::quantified_comparison_predicate_t& pred) {
     to_yaml(ptr, out, pred.op);
-    ptr.indent(out) << "left: " << *pred.left;
+    ptr.indent(out) << "left:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.left);
+    ptr.indent_pop(out);
     if (pred.quantifier == sqltoast::QUANTIFIER_ALL)
         ptr.indent(out) << "quantifier: ALL";
     else
@@ -806,7 +833,10 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::unique_predicate
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::match_predicate_t& pred) {
-    ptr.indent(out) << "left: " << *pred.left;
+    ptr.indent(out) << "left:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.left);
+    ptr.indent_pop(out);
     if (pred.match_unique)
         ptr.indent(out) << "unique: true";
     if (pred.match_partial)
@@ -818,8 +848,14 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::match_predicate_
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::overlaps_predicate_t& pred) {
-    ptr.indent(out) << "left: " << *pred.left;
-    ptr.indent(out) << "right: " << *pred.right;
+    ptr.indent(out) << "left:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.left);
+    ptr.indent_pop(out);
+    ptr.indent(out) << "right:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *pred.right);
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_primary_t& bp) {
@@ -848,6 +884,63 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_term_t& 
         ptr.indent_pop(out);
         ptr.indent_pop(out);
     }
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::row_value_constructor_t& rvc) {
+    switch (rvc.rvc_type) {
+        case sqltoast::RVC_TYPE_ELEMENT:
+            {
+                const sqltoast::row_value_constructor_element_t& el =
+                    static_cast<const sqltoast::row_value_constructor_element_t&>(rvc);
+                to_yaml(ptr, out, el, false);
+            }
+            break;
+        case sqltoast::RVC_TYPE_LIST:
+            {
+                const sqltoast::row_value_constructor_list_t& els =
+                    static_cast<const sqltoast::row_value_constructor_list_t&>(rvc);
+                for (const auto& rvc_el : els.elements) {
+                    const sqltoast::row_value_constructor_element_t& el =
+                        static_cast<const sqltoast::row_value_constructor_element_t&>(*rvc_el);
+                    to_yaml(ptr, out, el, true);
+                }
+            }
+            break;
+        case sqltoast::RVC_TYPE_SUBQUERY:
+            // TODO
+            out << "row-value-constructor-subquery";
+            break;
+    }
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::row_value_constructor_element_t& rvce, bool list_item) {
+    std::string prefix;
+    if (list_item)
+        prefix.assign("- ");
+    switch (rvce.rvc_element_type) {
+        case sqltoast::RVC_ELEMENT_TYPE_DEFAULT:
+            ptr.indent(out) << prefix << "element_type: DEFAULT";
+            break;
+        case sqltoast::RVC_ELEMENT_TYPE_NULL:
+            ptr.indent(out) << prefix << "element_type: NULL";
+            break;
+        case sqltoast::RVC_ELEMENT_TYPE_VALUE_EXPRESSION:
+            ptr.indent(out) << prefix << "element_type: VALUE_EXPRESSION";
+            if (list_item)
+                ptr.indent_push(out);
+            {
+                const sqltoast::row_value_expression_t& val =
+                    static_cast<const sqltoast::row_value_expression_t&>(rvce);
+                to_yaml(ptr, out, val);
+            }
+            if (list_item)
+                ptr.indent_pop(out);
+            break;
+    }
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::row_value_expression_t& rve) {
+    ptr.indent(out) << "value: " << *rve.value;
 }
 
 } // namespace sqltoast::print

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -19,6 +19,12 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::add_constraint_a
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::alter_column_action_t& action);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::alter_table_action_t& action);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::alter_table_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::between_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_factor_t& bf);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_primary_t& bp);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_term_t& bt);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::comp_op_t& op);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::comp_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_schema_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_table_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_view_statement_t& stmt);
@@ -28,21 +34,32 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_column_acti
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_schema_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_table_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_view_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::exists_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_action_t& action);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_subquery_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_values_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_select_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_statement_t& stmt);
-void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::joined_table_t& jt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::joined_table_query_expression_t& qe);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::joined_table_t& jt);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::like_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::match_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::non_join_query_expression_t& qe);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::non_join_query_primary_t& primary);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::non_join_query_term_t& term);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::null_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::overlaps_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::quantified_comparison_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::query_expression_t& qe);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::query_specification_non_join_query_primary_t& primary);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::query_specification_t& query);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::search_condition_t& sc);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::select_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_expression_t& table_exp);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::unique_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::update_statement_t& stmt);
 
 } // namespace sqltoaster::print

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -55,6 +55,9 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::quantified_compa
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::query_expression_t& qe);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::query_specification_non_join_query_primary_t& primary);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::query_specification_t& query);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::row_value_constructor_element_t& rvce, bool list_item);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::row_value_constructor_t& rvc);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::row_value_expression_t& rve);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::search_condition_t& sc);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::select_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stmt);

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -9,7 +9,7 @@
 
 #include <sqltoast/print.h>
 
-#include "../../printer.h"
+#include "../printer.h"
 
 namespace sqltoaster {
 namespace print {
@@ -45,7 +45,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_expression_t& table_exp);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::update_statement_t& stmt);
 
-} // namespace sqltoast::print
-} // namespace sqltoast
+} // namespace sqltoaster::print
+} // namespace sqltoaster
 
 #endif /* SQLTOASTER_PRINT_YAML_PRINTERS_H */

--- a/sqltoaster/printer.cc
+++ b/sqltoaster/printer.cc
@@ -5,7 +5,7 @@
  */
 
 #include "printer.h"
-#include "print/yaml/printers.h"
+#include "print/yaml.h"
 
 namespace sqltoaster {
 

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -6,7 +6,11 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = literal[10]
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: literal[10]
 # anti-equality comparison predicate
 >SELECT * FROM t1 WHERE a <> 10
 statements:
@@ -15,7 +19,11 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] <> literal[10]
+  where:
+    - predicate_type: COMPARISON
+      op: NOT_EQUAL
+      left: column-reference[a]
+      right: literal[10]
 # Order of value expressions should not matter in equality comparison
 >SELECT * FROM t1 WHERE 10 = a
 statements:
@@ -24,7 +32,11 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: literal[10] = column-reference[a]
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: literal[10]
+      right: column-reference[a]
 # Compound predicate with AND of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 AND b = 2
 statements:
@@ -33,7 +45,16 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = literal[1] AND column-reference[b] = literal[2]
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: literal[1]
+      and:
+        - predicate_type: COMPARISON
+          op: EQUAL
+          left: column-reference[b]
+          right: literal[2]
 # Compound predicate with OR of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 OR b = 2
 statements:
@@ -42,7 +63,15 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = literal[1] OR column-reference[b] = literal[2]
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: literal[1]
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[b]
+      right: literal[2]
 # Compound predicate with both AND and OR operators
 >SELECT * FROM t1 WHERE a = 1 AND b = 2 OR c = 3
 statements:
@@ -51,7 +80,20 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = literal[1] AND column-reference[b] = literal[2] OR column-reference[c] = literal[3]
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: literal[1]
+      and:
+        - predicate_type: COMPARISON
+          op: EQUAL
+          left: column-reference[b]
+          right: literal[2]
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[c]
+      right: literal[3]
 # Compound predicate with both OR and AND operators. The AND should take
 # precedence
 >SELECT * FROM t1 WHERE a = 1 OR b = 2 AND c = 3
@@ -61,7 +103,20 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = literal[1] OR column-reference[b] = literal[2] AND column-reference[c] = literal[3]
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: literal[1]
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[b]
+      right: literal[2]
+      and:
+        - predicate_type: COMPARISON
+          op: EQUAL
+          left: column-reference[c]
+          right: literal[3]
 # Compound predicate with both AND and OR operators using parens for precedence
 # override
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3)
@@ -71,7 +126,20 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = literal[1] AND (column-reference[b] = literal[2] OR column-reference[c] = literal[3])
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: literal[1]
+      and:
+        - predicate_type: COMPARISON
+          op: EQUAL
+          left: column-reference[b]
+          right: literal[2]
+        - predicate_type: COMPARISON
+          op: EQUAL
+          left: column-reference[c]
+          right: literal[3]
 # Multiple nested search conditions using parens for precedence
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3 AND (d = 4 OR e = 5))
 statements:
@@ -80,7 +148,29 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = literal[1] AND (column-reference[b] = literal[2] OR column-reference[c] = literal[3] AND (column-reference[d] = literal[4] OR column-reference[e] = literal[5]))
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: literal[1]
+      and:
+        - predicate_type: COMPARISON
+          op: EQUAL
+          left: column-reference[b]
+          right: literal[2]
+        - predicate_type: COMPARISON
+          op: EQUAL
+          left: column-reference[c]
+          right: literal[3]
+          and:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left: column-reference[d]
+              right: literal[4]
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left: column-reference[e]
+              right: literal[5]
 # IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE a IN (1)
 statements:
@@ -89,7 +179,11 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] IN (literal[1])
+  where:
+    - predicate_type: IN_VALUES
+      left: column-reference[a]
+      values:
+        - literal[1]
 # Negate of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE a NOT IN (1)
 statements:
@@ -98,7 +192,12 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] NOT IN (literal[1])
+  where:
+    - predicate_type: IN_VALUES
+      left: column-reference[a]
+      predicate_negate: true
+      values:
+        - literal[1]
 # top-level negation of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE NOT a IN (1)
 statements:
@@ -107,7 +206,12 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: NOT column-reference[a] IN (literal[1])
+  where:
+    - predicate_type: IN_VALUES
+      left: column-reference[a]
+      values:
+        - literal[1]
+      factor_negate: true
 # double-negation of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE NOT a NOT IN (1)
 statements:
@@ -116,7 +220,13 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: NOT column-reference[a] NOT IN (literal[1])
+  where:
+    - predicate_type: IN_VALUES
+      left: column-reference[a]
+      predicate_negate: true
+      values:
+        - literal[1]
+      factor_negate: true
 # IN (<value list>) operator with multiple value
 >SELECT * FROM t1 WHERE a IN (1, 2, 3)
 statements:
@@ -125,7 +235,13 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] IN (literal[1],literal[2],literal[3])
+  where:
+    - predicate_type: IN_VALUES
+      left: column-reference[a]
+      values:
+        - literal[1]
+        - literal[2]
+        - literal[3]
 # IN (<value list>) operator with complex value expressions
 >SELECT * FROM t1 WHERE a IN (1 - b, CHAR_LENGTH(b))
 statements:
@@ -134,7 +250,12 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] IN (numeric-expression[literal[1] - column-reference[b]],char-length[column-reference[b]])
+  where:
+    - predicate_type: IN_VALUES
+      left: column-reference[a]
+      values:
+        - numeric-expression[literal[1] - column-reference[b]]
+        - char-length[column-reference[b]]
 # IN (<subquery>) operator
 >SELECT * FROM t1 WHERE a IN (SELECT t1_a FROM t2)
 statements:
@@ -143,7 +264,14 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] IN query[selected-columns[column-reference[t1_a]] table-expression[referenced-tables[t2]]
+  where:
+    - predicate_type: IN_SUBQUERY
+      left: column-reference[a]
+      query:
+        selected_columns:
+          - column-reference[t1_a]
+        referenced_tables:
+          - t2
 # EXISTS (<subquery>) predicate
 >SELECT * FROM t1 WHERE EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -152,7 +280,18 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: EXISTS query[selected-columns[column-reference[t1_id]] table-expression[referenced-tables[t2 where[column-reference[t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: EXISTS
+      query:
+        selected_columns:
+          - column-reference[t1_id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t1_id]
+            right: column-reference[t1.id]
 # NOT EXISTS (<subquery>) predicate
 >SELECT * FROM t1 WHERE NOT EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -161,7 +300,19 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: NOT EXISTS query[selected-columns[column-reference[t1_id]] table-expression[referenced-tables[t2 where[column-reference[t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: EXISTS
+      query:
+        selected_columns:
+          - column-reference[t1_id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t1_id]
+            right: column-reference[t1.id]
+      factor_negate: true
 # <row> MATCH (<subquery>) predicate
 >SELECT * FROM t1 WHERE id MATCH (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -170,7 +321,19 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[id] MATCH FULL query[selected-columns[column-reference[t1_id]] table-expression[referenced-tables[t2 where[column-reference[t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: MATCH
+      left: column-reference[id]
+      query:
+        selected_columns:
+          - column-reference[t1_id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t1_id]
+            right: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate explicit FULL
 >SELECT * FROM t1 WHERE id MATCH FULL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -179,7 +342,19 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[id] MATCH FULL query[selected-columns[column-reference[t1_id]] table-expression[referenced-tables[t2 where[column-reference[t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: MATCH
+      left: column-reference[id]
+      query:
+        selected_columns:
+          - column-reference[t1_id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t1_id]
+            right: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate with UNIQUE
 >SELECT * FROM t1 WHERE id MATCH UNIQUE (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -188,7 +363,20 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[id] MATCH UNIQUE FULL query[selected-columns[column-reference[t1_id]] table-expression[referenced-tables[t2 where[column-reference[t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: MATCH
+      left: column-reference[id]
+      unique: true
+      query:
+        selected_columns:
+          - column-reference[t1_id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t1_id]
+            right: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate explicit PARTIAL
 >SELECT * FROM t1 WHERE id MATCH PARTIAL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -197,7 +385,20 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[id] MATCH PARTIAL query[selected-columns[column-reference[t1_id]] table-expression[referenced-tables[t2 where[column-reference[t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: MATCH
+      left: column-reference[id]
+      partial: true
+      query:
+        selected_columns:
+          - column-reference[t1_id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t1_id]
+            right: column-reference[t1.id]
 # LIKE predicate with simple column comparison with string
 >SELECT * FROM t1 WHERE a LIKE 's%'
 statements:
@@ -206,7 +407,10 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] LIKE literal['s%']
+  where:
+    - predicate_type: LIKE
+      match: column-reference[a]
+      pattern: literal['s%']
 # LIKE predicate with concatenated column comparison with string
 >SELECT * FROM t1 WHERE a LIKE b || '%'
 statements:
@@ -215,7 +419,10 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] LIKE concatenate[column-reference[b], literal['%']]
+  where:
+    - predicate_type: LIKE
+      match: column-reference[a]
+      pattern: concatenate[column-reference[b], literal['%']]
 # OVERLAPS predicate with date columns from multiple tables
 >SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
 statements:
@@ -225,7 +432,10 @@ statements:
   referenced_tables:
     - t1
     - t2
-  where: (column-reference[t1.start],column-reference[t1.end]) OVERLAPS (column-reference[t2.start],column-reference[t2.end])
+  where:
+    - predicate_type: OVERLAPS
+      left: (column-reference[t1.start],column-reference[t1.end])
+      right: (column-reference[t2.start],column-reference[t2.end])
 # the UNIQUE predicate returns a match when the correlation returns one and
 # only one row
 >SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
@@ -235,7 +445,18 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: UNIQUE query[selected-columns[column-reference[t2.id]] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: UNIQUE
+      query:
+        selected_columns:
+          - column-reference[t2.id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t2.t1_id]
+            right: column-reference[t1.id]
 # negated UNIQUE predicate
 >SELECT * FROM t1 WHERE NOT UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
 statements:
@@ -244,7 +465,19 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: NOT UNIQUE query[selected-columns[column-reference[t2.id]] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: UNIQUE
+      query:
+        selected_columns:
+          - column-reference[t2.id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t2.t1_id]
+            right: column-reference[t1.id]
+      factor_negate: true
 # Combine EXISTS and UNIQUE predicate
 >SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id) AND EXISTS (SELECT t3.id FROM t3 WHERE t3.t1_id = t1.id);
 statements:
@@ -253,7 +486,30 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: UNIQUE query[selected-columns[column-reference[t2.id]] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]] AND EXISTS query[selected-columns[column-reference[t3.id]] table-expression[referenced-tables[t3 where[column-reference[t3.t1_id] = column-reference[t1.id]]]]
+  where:
+    - predicate_type: UNIQUE
+      query:
+        selected_columns:
+          - column-reference[t2.id]
+        referenced_tables:
+          - t2
+        where:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left: column-reference[t2.t1_id]
+            right: column-reference[t1.id]
+      and:
+        - predicate_type: EXISTS
+          query:
+            selected_columns:
+              - column-reference[t3.id]
+            referenced_tables:
+              - t3
+            where:
+              - predicate_type: COMPARISON
+                op: EQUAL
+                left: column-reference[t3.t1_id]
+                right: column-reference[t1.id]
 # quantified comparison predicates are like comparison predicates with an
 # ANY|ALL|SOME quantifier
 >SELECT * FROM t1 WHERE t1.start > ALL (SELECT t2.start FROM t2)
@@ -263,7 +519,16 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[t1.start] > ALL query[selected-columns[column-reference[t2.start]] table-expression[referenced-tables[t2]]
+  where:
+    - predicate_type: QUANTIFIED_COMPARISON
+      op: GREATER_THAN
+      left: column-reference[t1.start]
+      quantifier: ALL
+      query:
+        selected_columns:
+          - column-reference[t2.start]
+        referenced_tables:
+          - t2
 # quantified comparison predicate with ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= ANY (SELECT t2.start FROM t2)
 statements:
@@ -272,7 +537,16 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[t1.start] <= ANY query[selected-columns[column-reference[t2.start]] table-expression[referenced-tables[t2]]
+  where:
+    - predicate_type: QUANTIFIED_COMPARISON
+      op: LESS_THAN_OR_EQUAL
+      left: column-reference[t1.start]
+      quantifier: ANY
+      query:
+        selected_columns:
+          - column-reference[t2.start]
+        referenced_tables:
+          - t2
 # quantified comparison predicate with SOME quantifier translated to ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= SOME (SELECT t2.start FROM t2)
 statements:
@@ -281,4 +555,13 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[t1.start] <= ANY query[selected-columns[column-reference[t2.start]] table-expression[referenced-tables[t2]]
+  where:
+    - predicate_type: QUANTIFIED_COMPARISON
+      op: LESS_THAN_OR_EQUAL
+      left: column-reference[t1.start]
+      quantifier: ANY
+      query:
+        selected_columns:
+          - column-reference[t2.start]
+        referenced_tables:
+          - t2

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -9,8 +9,12 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: literal[10]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[10]
 # anti-equality comparison predicate
 >SELECT * FROM t1 WHERE a <> 10
 statements:
@@ -22,8 +26,12 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: NOT_EQUAL
-      left: column-reference[a]
-      right: literal[10]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[10]
 # Order of value expressions should not matter in equality comparison
 >SELECT * FROM t1 WHERE 10 = a
 statements:
@@ -35,8 +43,12 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: literal[10]
-      right: column-reference[a]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: literal[10]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
 # Compound predicate with AND of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 AND b = 2
 statements:
@@ -48,13 +60,21 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: literal[1]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[1]
       and:
         - predicate_type: COMPARISON
           op: EQUAL
-          left: column-reference[b]
-          right: literal[2]
+          left:
+            element_type: VALUE_EXPRESSION
+            value: column-reference[b]
+          right:
+            element_type: VALUE_EXPRESSION
+            value: literal[2]
 # Compound predicate with OR of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 OR b = 2
 statements:
@@ -66,12 +86,20 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: literal[1]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[1]
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[b]
-      right: literal[2]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[b]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[2]
 # Compound predicate with both AND and OR operators
 >SELECT * FROM t1 WHERE a = 1 AND b = 2 OR c = 3
 statements:
@@ -83,17 +111,29 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: literal[1]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[1]
       and:
         - predicate_type: COMPARISON
           op: EQUAL
-          left: column-reference[b]
-          right: literal[2]
+          left:
+            element_type: VALUE_EXPRESSION
+            value: column-reference[b]
+          right:
+            element_type: VALUE_EXPRESSION
+            value: literal[2]
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[c]
-      right: literal[3]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[c]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[3]
 # Compound predicate with both OR and AND operators. The AND should take
 # precedence
 >SELECT * FROM t1 WHERE a = 1 OR b = 2 AND c = 3
@@ -106,17 +146,29 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: literal[1]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[1]
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[b]
-      right: literal[2]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[b]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[2]
       and:
         - predicate_type: COMPARISON
           op: EQUAL
-          left: column-reference[c]
-          right: literal[3]
+          left:
+            element_type: VALUE_EXPRESSION
+            value: column-reference[c]
+          right:
+            element_type: VALUE_EXPRESSION
+            value: literal[3]
 # Compound predicate with both AND and OR operators using parens for precedence
 # override
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3)
@@ -129,17 +181,29 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: literal[1]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[1]
       and:
         - predicate_type: COMPARISON
           op: EQUAL
-          left: column-reference[b]
-          right: literal[2]
+          left:
+            element_type: VALUE_EXPRESSION
+            value: column-reference[b]
+          right:
+            element_type: VALUE_EXPRESSION
+            value: literal[2]
         - predicate_type: COMPARISON
           op: EQUAL
-          left: column-reference[c]
-          right: literal[3]
+          left:
+            element_type: VALUE_EXPRESSION
+            value: column-reference[c]
+          right:
+            element_type: VALUE_EXPRESSION
+            value: literal[3]
 # Multiple nested search conditions using parens for precedence
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3 AND (d = 4 OR e = 5))
 statements:
@@ -151,26 +215,46 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: literal[1]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: literal[1]
       and:
         - predicate_type: COMPARISON
           op: EQUAL
-          left: column-reference[b]
-          right: literal[2]
+          left:
+            element_type: VALUE_EXPRESSION
+            value: column-reference[b]
+          right:
+            element_type: VALUE_EXPRESSION
+            value: literal[2]
         - predicate_type: COMPARISON
           op: EQUAL
-          left: column-reference[c]
-          right: literal[3]
+          left:
+            element_type: VALUE_EXPRESSION
+            value: column-reference[c]
+          right:
+            element_type: VALUE_EXPRESSION
+            value: literal[3]
           and:
             - predicate_type: COMPARISON
               op: EQUAL
-              left: column-reference[d]
-              right: literal[4]
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[d]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: literal[4]
             - predicate_type: COMPARISON
               op: EQUAL
-              left: column-reference[e]
-              right: literal[5]
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[e]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: literal[5]
 # IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE a IN (1)
 statements:
@@ -181,7 +265,9 @@ statements:
     - t1
   where:
     - predicate_type: IN_VALUES
-      left: column-reference[a]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       values:
         - literal[1]
 # Negate of IN (<value list>) operator with single value
@@ -194,7 +280,9 @@ statements:
     - t1
   where:
     - predicate_type: IN_VALUES
-      left: column-reference[a]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       predicate_negate: true
       values:
         - literal[1]
@@ -208,7 +296,9 @@ statements:
     - t1
   where:
     - predicate_type: IN_VALUES
-      left: column-reference[a]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       values:
         - literal[1]
       factor_negate: true
@@ -222,7 +312,9 @@ statements:
     - t1
   where:
     - predicate_type: IN_VALUES
-      left: column-reference[a]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       predicate_negate: true
       values:
         - literal[1]
@@ -237,7 +329,9 @@ statements:
     - t1
   where:
     - predicate_type: IN_VALUES
-      left: column-reference[a]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       values:
         - literal[1]
         - literal[2]
@@ -252,7 +346,9 @@ statements:
     - t1
   where:
     - predicate_type: IN_VALUES
-      left: column-reference[a]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       values:
         - numeric-expression[literal[1] - column-reference[b]]
         - char-length[column-reference[b]]
@@ -266,7 +362,9 @@ statements:
     - t1
   where:
     - predicate_type: IN_SUBQUERY
-      left: column-reference[a]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       query:
         selected_columns:
           - column-reference[t1_a]
@@ -290,8 +388,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
 # NOT EXISTS (<subquery>) predicate
 >SELECT * FROM t1 WHERE NOT EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -310,8 +412,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
       factor_negate: true
 # <row> MATCH (<subquery>) predicate
 >SELECT * FROM t1 WHERE id MATCH (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
@@ -323,7 +429,9 @@ statements:
     - t1
   where:
     - predicate_type: MATCH
-      left: column-reference[id]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[id]
       query:
         selected_columns:
           - column-reference[t1_id]
@@ -332,8 +440,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate explicit FULL
 >SELECT * FROM t1 WHERE id MATCH FULL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -344,7 +456,9 @@ statements:
     - t1
   where:
     - predicate_type: MATCH
-      left: column-reference[id]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[id]
       query:
         selected_columns:
           - column-reference[t1_id]
@@ -353,8 +467,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate with UNIQUE
 >SELECT * FROM t1 WHERE id MATCH UNIQUE (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -365,7 +483,9 @@ statements:
     - t1
   where:
     - predicate_type: MATCH
-      left: column-reference[id]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[id]
       unique: true
       query:
         selected_columns:
@@ -375,8 +495,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate explicit PARTIAL
 >SELECT * FROM t1 WHERE id MATCH PARTIAL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -387,7 +511,9 @@ statements:
     - t1
   where:
     - predicate_type: MATCH
-      left: column-reference[id]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[id]
       partial: true
       query:
         selected_columns:
@@ -397,8 +523,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
 # LIKE predicate with simple column comparison with string
 >SELECT * FROM t1 WHERE a LIKE 's%'
 statements:
@@ -409,7 +539,9 @@ statements:
     - t1
   where:
     - predicate_type: LIKE
-      match: column-reference[a]
+      match:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       pattern: literal['s%']
 # LIKE predicate with concatenated column comparison with string
 >SELECT * FROM t1 WHERE a LIKE b || '%'
@@ -421,7 +553,9 @@ statements:
     - t1
   where:
     - predicate_type: LIKE
-      match: column-reference[a]
+      match:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
       pattern: concatenate[column-reference[b], literal['%']]
 # OVERLAPS predicate with date columns from multiple tables
 >SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
@@ -434,8 +568,16 @@ statements:
     - t2
   where:
     - predicate_type: OVERLAPS
-      left: (column-reference[t1.start],column-reference[t1.end])
-      right: (column-reference[t2.start],column-reference[t2.end])
+      left:
+        - element_type: VALUE_EXPRESSION
+          value: column-reference[t1.start]
+        - element_type: VALUE_EXPRESSION
+          value: column-reference[t1.end]
+      right:
+        - element_type: VALUE_EXPRESSION
+          value: column-reference[t2.start]
+        - element_type: VALUE_EXPRESSION
+          value: column-reference[t2.end]
 # the UNIQUE predicate returns a match when the correlation returns one and
 # only one row
 >SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
@@ -455,8 +597,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t2.t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t2.t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
 # negated UNIQUE predicate
 >SELECT * FROM t1 WHERE NOT UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
 statements:
@@ -475,8 +621,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t2.t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t2.t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
       factor_negate: true
 # Combine EXISTS and UNIQUE predicate
 >SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id) AND EXISTS (SELECT t3.id FROM t3 WHERE t3.t1_id = t1.id);
@@ -496,8 +646,12 @@ statements:
         where:
           - predicate_type: COMPARISON
             op: EQUAL
-            left: column-reference[t2.t1_id]
-            right: column-reference[t1.id]
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t2.t1_id]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[t1.id]
       and:
         - predicate_type: EXISTS
           query:
@@ -508,8 +662,12 @@ statements:
             where:
               - predicate_type: COMPARISON
                 op: EQUAL
-                left: column-reference[t3.t1_id]
-                right: column-reference[t1.id]
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[t3.t1_id]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[t1.id]
 # quantified comparison predicates are like comparison predicates with an
 # ANY|ALL|SOME quantifier
 >SELECT * FROM t1 WHERE t1.start > ALL (SELECT t2.start FROM t2)
@@ -522,7 +680,9 @@ statements:
   where:
     - predicate_type: QUANTIFIED_COMPARISON
       op: GREATER_THAN
-      left: column-reference[t1.start]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[t1.start]
       quantifier: ALL
       query:
         selected_columns:
@@ -540,7 +700,9 @@ statements:
   where:
     - predicate_type: QUANTIFIED_COMPARISON
       op: LESS_THAN_OR_EQUAL
-      left: column-reference[t1.start]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[t1.start]
       quantifier: ANY
       query:
         selected_columns:
@@ -558,7 +720,9 @@ statements:
   where:
     - predicate_type: QUANTIFIED_COMPARISON
       op: LESS_THAN_OR_EQUAL
-      left: column-reference[t1.start]
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[t1.start]
       quantifier: ANY
       query:
         selected_columns:

--- a/tests/grammar/ansi-92/row-value-constructors.test
+++ b/tests/grammar/ansi-92/row-value-constructors.test
@@ -10,8 +10,16 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: (column-reference[a],column-reference[b])
-      right: (column-reference[b],column-reference[a])
+      left:
+        - element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        - element_type: VALUE_EXPRESSION
+          value: column-reference[b]
+      right:
+        - element_type: VALUE_EXPRESSION
+          value: column-reference[b]
+        - element_type: VALUE_EXPRESSION
+          value: column-reference[a]
 # Single-value row value constructor lists are OK too
 >SELECT * FROM t1 WHERE (a) = (b)
 statements:
@@ -23,8 +31,12 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: (column-reference[a])
-      right: (column-reference[b])
+      left:
+        element_type: VALUE_EXPRESSION
+        value: (column-reference[a])
+      right:
+        element_type: VALUE_EXPRESSION
+        value: (column-reference[b])
 # scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2)
 statements:
@@ -36,8 +48,12 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: scalar-subquery[
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
 # scalar subquery inside another scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2 WHERE b = (SELECT c FROM t3))
@@ -50,8 +66,12 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[a]
-      right: scalar-subquery[
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[a]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2 where[column-reference[b] = scalar-subquery[
 query[selected-columns[column-reference[c]] table-expression[referenced-tables[t3]]]]]]]
 # scalar subquery with correlation and alias
@@ -65,6 +85,10 @@ statements:
   where:
     - predicate_type: COMPARISON
       op: EQUAL
-      left: column-reference[num_t2]
-      right: scalar-subquery[
+      left:
+        element_type: VALUE_EXPRESSION
+        value: column-reference[num_t2]
+      right:
+        element_type: VALUE_EXPRESSION
+        value: scalar-subquery[
 query[selected-columns[COUNT(*)] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]]

--- a/tests/grammar/ansi-92/row-value-constructors.test
+++ b/tests/grammar/ansi-92/row-value-constructors.test
@@ -7,7 +7,11 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: (column-reference[a],column-reference[b]) = (column-reference[b],column-reference[a])
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: (column-reference[a],column-reference[b])
+      right: (column-reference[b],column-reference[a])
 # Single-value row value constructor lists are OK too
 >SELECT * FROM t1 WHERE (a) = (b)
 statements:
@@ -16,7 +20,11 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: (column-reference[a]) = (column-reference[b])
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: (column-reference[a])
+      right: (column-reference[b])
 # scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2)
 statements:
@@ -25,7 +33,11 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = scalar-subquery[
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
 # scalar subquery inside another scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2 WHERE b = (SELECT c FROM t3))
@@ -35,7 +47,11 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[a] = scalar-subquery[
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[a]
+      right: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2 where[column-reference[b] = scalar-subquery[
 query[selected-columns[column-reference[c]] table-expression[referenced-tables[t3]]]]]]]
 # scalar subquery with correlation and alias
@@ -46,5 +62,9 @@ statements:
     - *
   referenced_tables:
     - t1
-  where: column-reference[num_t2] = scalar-subquery[
+  where:
+    - predicate_type: COMPARISON
+      op: EQUAL
+      left: column-reference[num_t2]
+      right: scalar-subquery[
 query[selected-columns[COUNT(*)] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]]


### PR DESCRIPTION
In order to properly model UNION/EXCEPT/INTERSECT, it was necessary to break the select_statement_t out into query_expression_t and query_specification_t. After doing that, it was necessary to break out YAML-specific printers for the various query components -- things like predicate_t. After that, it was necessary to break out YAML-specific printers for row value constructors and their elements.

Issue #104