### PR TITLE
Correct YAML output for various structs

### DIFF
--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -12,8 +12,10 @@ namespace sqltoaster {
 namespace print {
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stmt) {
-    if (ptr.in_list(out))
+    if (ptr.in_list(out)) {
         ptr.indent(out) << "- type: ";
+        ptr.end_list(out);
+    }
     else
         ptr.indent(out) << "type: ";
     ptr.indent_push(out);
@@ -606,15 +608,24 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::search_condition
     // OR'd operands are on the same "level" as each other for evaluation
     // purposes, which is why we don't attempt to indent here and just
     // output the terms in a list
-    for (const std::unique_ptr<sqltoast::boolean_term_t>& or_term_p : sc.terms)
+    ptr.indent(out) << "search_condition:";
+    ptr.indent_push(out);
+    ptr.indent(out) << "terms:";
+    ptr.indent_push(out);
+    for (const std::unique_ptr<sqltoast::boolean_term_t>& or_term_p : sc.terms) {
+        ptr.start_list(out);
         to_yaml(ptr, out, *or_term_p);
+    }
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pred) {
+    ptr.indent(out) << "predicate:";
+    ptr.indent_push(out);
+    ptr.indent(out) << "type: ";
     switch (pred.predicate_type) {
         case sqltoast::PREDICATE_TYPE_COMPARISON:
-            ptr.indent(out) << "- predicate_type: COMPARISON";
-            ptr.indent_push(out);
+            out << "COMPARISON";
             {
                 const sqltoast::comp_predicate_t& sub =
                     static_cast<const sqltoast::comp_predicate_t&>(pred);
@@ -622,8 +633,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_BETWEEN:
-            ptr.indent(out) << "- predicate_type: BETWEEN";
-            ptr.indent_push(out);
+            out << "BETWEEN";
             {
                 const sqltoast::between_predicate_t& sub =
                     static_cast<const sqltoast::between_predicate_t&>(pred);
@@ -631,8 +641,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_LIKE:
-            ptr.indent(out) << "- predicate_type: LIKE";
-            ptr.indent_push(out);
+            out << "LIKE";
             {
                 const sqltoast::like_predicate_t& sub =
                     static_cast<const sqltoast::like_predicate_t&>(pred);
@@ -640,8 +649,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_NULL:
-            ptr.indent(out) << "- predicate_type: NULL";
-            ptr.indent_push(out);
+            out << "NULL";
             {
                 const sqltoast::null_predicate_t& sub =
                     static_cast<const sqltoast::null_predicate_t&>(pred);
@@ -649,8 +657,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_IN_VALUES:
-            ptr.indent(out) << "- predicate_type: IN_VALUES";
-            ptr.indent_push(out);
+            out << "IN_VALUES";
             {
                 const sqltoast::in_values_predicate_t& sub =
                     static_cast<const sqltoast::in_values_predicate_t&>(pred);
@@ -658,8 +665,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_IN_SUBQUERY:
-            ptr.indent(out) << "- predicate_type: IN_SUBQUERY";
-            ptr.indent_push(out);
+            out << "IN_SUBQUERY";
             {
                 const sqltoast::in_subquery_predicate_t& sub =
                     static_cast<const sqltoast::in_subquery_predicate_t&>(pred);
@@ -667,8 +673,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_QUANTIFIED_COMPARISON:
-            ptr.indent(out) << "- predicate_type: QUANTIFIED_COMPARISON";
-            ptr.indent_push(out);
+            out << "QUANTIFIED_COMPARISON";
             {
                 const sqltoast::quantified_comparison_predicate_t& sub =
                     static_cast<const sqltoast::quantified_comparison_predicate_t&>(pred);
@@ -676,8 +681,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_EXISTS:
-            ptr.indent(out) << "- predicate_type: EXISTS";
-            ptr.indent_push(out);
+            out << "EXISTS";
             {
                 const sqltoast::exists_predicate_t& sub =
                     static_cast<const sqltoast::exists_predicate_t&>(pred);
@@ -685,8 +689,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_UNIQUE:
-            ptr.indent(out) << "- predicate_type: UNIQUE";
-            ptr.indent_push(out);
+            out << "UNIQUE";
             {
                 const sqltoast::unique_predicate_t& sub =
                     static_cast<const sqltoast::unique_predicate_t&>(pred);
@@ -694,8 +697,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_MATCH:
-            ptr.indent(out) << "- predicate_type: MATCH";
-            ptr.indent_push(out);
+            out << "MATCH";
             {
                 const sqltoast::match_predicate_t& sub =
                     static_cast<const sqltoast::match_predicate_t&>(pred);
@@ -703,8 +705,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pre
             }
             break;
         case sqltoast::PREDICATE_TYPE_OVERLAPS:
-            ptr.indent(out) << "- predicate_type: OVERLAPS";
-            ptr.indent_push(out);
+            out << "OVERLAPS";
             {
                 const sqltoast::overlaps_predicate_t& sub =
                     static_cast<const sqltoast::overlaps_predicate_t&>(pred);
@@ -772,7 +773,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::like_predicate_t
     to_yaml(ptr, out, *pred.match);
     ptr.indent_pop(out);
     if (pred.reverse_op)
-        ptr.indent(out) << "predicate_negate: true";
+        ptr.indent(out) << "negate: true";
     ptr.indent(out) << "pattern: " << *pred.pattern;
     if (pred.escape_char)
         ptr.indent(out) << "escape_char: " << *pred.escape_char;
@@ -789,7 +790,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_values_predic
     to_yaml(ptr, out, *pred.left);
     ptr.indent_pop(out);
     if (pred.reverse_op)
-        ptr.indent(out) << "predicate_negate: true";
+        ptr.indent(out) << "negate: true";
     ptr.indent(out) << "values:";
     ptr.indent_push(out);
     for (auto& ve : pred.values)
@@ -873,23 +874,32 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_primary_
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_factor_t& bf) {
     to_yaml(ptr, out, *bf.primary);
-    if (bf.reverse_op) {
-        ptr.indent_push(out);
-        ptr.indent(out) << "factor_negate: true";
-        ptr.indent_pop(out);
-    }
+    if (bf.reverse_op)
+        ptr.indent(out) << "negate: true";
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_term_t& bt) {
-    to_yaml(ptr, out, *bt.factor);
-    if (bt.and_operand) {
+    // Need to save whether this was a list item so we can properly de-indent
+    // at the end
+    bool is_list = ptr.in_list(out);
+    if (is_list) {
+        ptr.indent(out) << "- factor:";
+        ptr.end_list(out);
         ptr.indent_push(out);
+    } else {
+        ptr.indent(out) << "factor:";
+    }
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *bt.factor);
+    ptr.indent_pop(out);
+    if (bt.and_operand) {
         ptr.indent(out) << "and:";
         ptr.indent_push(out);
         to_yaml(ptr, out, *bt.and_operand);
         ptr.indent_pop(out);
-        ptr.indent_pop(out);
     }
+    if (is_list)
+        ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::row_value_constructor_t& rvc) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -12,9 +12,14 @@ namespace sqltoaster {
 namespace print {
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stmt) {
+    if (ptr.in_list(out))
+        ptr.indent(out) << "- type: ";
+    else
+        ptr.indent(out) << "type: ";
+    ptr.indent_push(out);
     switch (stmt.type) {
         case sqltoast::STATEMENT_TYPE_CREATE_SCHEMA:
-            ptr.indent_noendl(out) << "type: CREATE_SCHEMA";
+            out << "CREATE_SCHEMA";
             {
                 const sqltoast::create_schema_statement_t& sub =
                     static_cast<const sqltoast::create_schema_statement_t&>(stmt);
@@ -22,7 +27,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_DROP_SCHEMA:
-            ptr.indent_noendl(out) << "type: DROP_SCHEMA";
+            out << "DROP_SCHEMA";
             {
                 const sqltoast::drop_schema_statement_t& sub =
                     static_cast<const sqltoast::drop_schema_statement_t&>(stmt);
@@ -30,7 +35,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_CREATE_TABLE:
-            ptr.indent_noendl(out) << "type: CREATE_TABLE";
+            out << "CREATE_TABLE";
             {
                 const sqltoast::create_table_statement_t& sub =
                     static_cast<const sqltoast::create_table_statement_t&>(stmt);
@@ -38,7 +43,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_DROP_TABLE:
-            ptr.indent_noendl(out) << "type: DROP_TABLE";
+            out << "DROP_TABLE";
             {
                 const sqltoast::drop_table_statement_t& sub =
                     static_cast<const sqltoast::drop_table_statement_t&>(stmt);
@@ -46,7 +51,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_ALTER_TABLE:
-            ptr.indent_noendl(out) << "type: ALTER_TABLE";
+            out << "ALTER_TABLE";
             {
                 const sqltoast::alter_table_statement_t& sub =
                     static_cast<const sqltoast::alter_table_statement_t&>(stmt);
@@ -54,7 +59,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_CREATE_VIEW:
-            ptr.indent_noendl(out) << "type: CREATE_VIEW";
+            out << "CREATE_VIEW";
             {
                 const sqltoast::create_view_statement_t& sub =
                     static_cast<const sqltoast::create_view_statement_t&>(stmt);
@@ -62,7 +67,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_DROP_VIEW:
-            ptr.indent_noendl(out) << "type: DROP_VIEW";
+            out << "DROP_VIEW";
             {
                 const sqltoast::drop_view_statement_t& sub =
                     static_cast<const sqltoast::drop_view_statement_t&>(stmt);
@@ -70,7 +75,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_SELECT:
-            ptr.indent_noendl(out) << "type: SELECT";
+            out << "SELECT";
             {
                 const sqltoast::select_statement_t& sub =
                     static_cast<const sqltoast::select_statement_t&>(stmt);
@@ -78,7 +83,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_INSERT:
-            ptr.indent_noendl(out) << "type: INSERT";
+            out << "INSERT";
             {
                 const sqltoast::insert_statement_t& sub =
                     static_cast<const sqltoast::insert_statement_t&>(stmt);
@@ -86,7 +91,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_INSERT_SELECT:
-            ptr.indent_noendl(out) << "type: INSERT_SELECT";
+            out << "INSERT_SELECT";
             {
                 const sqltoast::insert_select_statement_t& sub =
                     static_cast<const sqltoast::insert_select_statement_t&>(stmt);
@@ -94,7 +99,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_DELETE:
-            ptr.indent_noendl(out) << "type: DELETE";
+            out << "DELETE";
             {
                 const sqltoast::delete_statement_t& sub =
                     static_cast<const sqltoast::delete_statement_t&>(stmt);
@@ -102,7 +107,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_UPDATE:
-            ptr.indent_noendl(out) << "type: UPDATE";
+            out << "UPDATE";
             {
                 const sqltoast::update_statement_t& sub =
                     static_cast<const sqltoast::update_statement_t&>(stmt);
@@ -110,13 +115,13 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
             }
             break;
         case sqltoast::STATEMENT_TYPE_COMMIT:
-            ptr.indent_noendl(out) << "type: COMMIT";
+            out << "COMMIT";
             break;
         case sqltoast::STATEMENT_TYPE_ROLLBACK:
-            ptr.indent_noendl(out) << "type: ROLLBACK";
+            out << "ROLLBACK";
             break;
         case sqltoast::STATEMENT_TYPE_GRANT:
-            ptr.indent_noendl(out) << "type: GRANT";
+            out << "GRANT";
             {
                 const sqltoast::grant_statement_t& sub =
                     static_cast<const sqltoast::grant_statement_t&>(stmt);
@@ -126,6 +131,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
         default:
             break;
     }
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_schema_statement_t& stmt) {

--- a/sqltoaster/printer.cc
+++ b/sqltoaster/printer.cc
@@ -20,14 +20,15 @@ std::ostream& operator<< (std::ostream& out, printer_t& ptr) {
         }
     } else {
         out << "statements:";
+        ptr.indent_push(out);
         for (auto stmt_ptr_it = ptr.res.statements.cbegin();
                 stmt_ptr_it != ptr.res.statements.cend();
                 stmt_ptr_it++) {
-            out << std::endl << "- ";
-            ptr.indent_push(out);
+            ptr.start_list(out);
             print::to_yaml(ptr, out, *(*stmt_ptr_it));
-            ptr.indent_pop(out);
+            ptr.end_list(out);
         }
+        ptr.indent_pop(out);
     }
     return out;
 }

--- a/sqltoaster/printer.h
+++ b/sqltoaster/printer.h
@@ -14,21 +14,29 @@
 
 namespace sqltoaster {
 
+const long LIST_ITEM_OFF = 0;
+const long LIST_ITEM_ON = 1;
+
 const long OUTPUT_FORMAT_DEFAULT = 1;
 const long OUTPUT_FORMAT_YAML = 2;
 
 const int OUTPUT_FORMAT_XALLOC_INDEX = 0;
 const int INDENT_LEVEL_XALLOC_INDEX = 1;
+// Informs the printer whether the current item to be printed is a list item
+const int LIST_ITEM_XALLOC_INDEX = 2;
 
 typedef struct printer {
-    int iomanip_indexes[2];
+    int iomanip_indexes[3];
     sqltoast::parse_result_t& res;
     printer(sqltoast::parse_result_t& res, std::ostream& out) : res(res)
     {
         iomanip_indexes[OUTPUT_FORMAT_XALLOC_INDEX] = std::ios_base::xalloc();
         iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX] = std::ios_base::xalloc();
+        iomanip_indexes[LIST_ITEM_XALLOC_INDEX] = std::ios_base::xalloc();
         int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
         out.iword(idx_indent) = 0;
+        int idx_list_item = iomanip_indexes[LIST_ITEM_XALLOC_INDEX];
+        out.iword(idx_list_item) = LIST_ITEM_OFF;
     }
     inline void set_yaml(std::ostream& out) {
         int idx_format = iomanip_indexes[OUTPUT_FORMAT_XALLOC_INDEX];
@@ -55,12 +63,16 @@ typedef struct printer {
             out << std::string(cur_indent * 2, ' ');
         return out;
     }
-    inline std::ostream& indent_noendl(std::ostream& out) {
-        int idx_indent = iomanip_indexes[INDENT_LEVEL_XALLOC_INDEX];
-        long cur_indent = out.iword(idx_indent);
-        if (cur_indent > 1)
-            out << std::string(cur_indent * 2, ' ');
-        return out;
+    inline void start_list(std::ostream& out) {
+        int idx_list_item = iomanip_indexes[LIST_ITEM_XALLOC_INDEX];
+        out.iword(idx_list_item) = LIST_ITEM_ON;
+    }
+    inline void end_list(std::ostream& out) {
+        int idx_list_item = iomanip_indexes[LIST_ITEM_XALLOC_INDEX];
+        out.iword(idx_list_item) = LIST_ITEM_OFF;
+    }
+    inline bool in_list(std::ostream& out) const {
+        return (out.iword(iomanip_indexes[LIST_ITEM_XALLOC_INDEX]) == LIST_ITEM_ON);
     }
 } printer_t;
 

--- a/tests/grammar/ansi-92/alter-table.test
+++ b/tests/grammar/ansi-92/alter-table.test
@@ -13,108 +13,108 @@ ALTER TABLE t1 ADD COLUMN b;
 # ADD COLUMN action
 >ALTER TABLE t1 ADD COLUMN b INT;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ADD COLUMN b INT
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ADD COLUMN b INT
 # ADD COLUMN action without optional COLUMN keyword
 >ALTER TABLE t1 ADD b INT;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ADD COLUMN b INT
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ADD COLUMN b INT
 # ALTER COLUMN SET DEFAULT action
 >ALTER TABLE t1 ALTER COLUMN b SET DEFAULT NULL;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ALTER COLUMN b SET DEFAULT NULL
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ALTER COLUMN b SET DEFAULT NULL
 # ALTER COLUMN SET DEFAULT action optional COLUMN keyword
 >ALTER TABLE t1 ALTER b SET DEFAULT NULL;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ALTER COLUMN b SET DEFAULT NULL
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ALTER COLUMN b SET DEFAULT NULL
 # ALTER COLUMN DROP DEFAULT action
 >ALTER TABLE t1 ALTER COLUMN b DROP DEFAULT;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ALTER COLUMN b DROP DEFAULT
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ALTER COLUMN b DROP DEFAULT
 # DROP COLUMN action no drop behaviour
 >ALTER TABLE t1 DROP COLUMN b;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: DROP COLUMN b CASCADE
+  - type: ALTER_TABLE
+    table_name: t1
+    action: DROP COLUMN b CASCADE
 # DROP COLUMN action no drop behaviour no optional COLUMN keyword
 >ALTER TABLE t1 DROP b;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: DROP COLUMN b CASCADE
+  - type: ALTER_TABLE
+    table_name: t1
+    action: DROP COLUMN b CASCADE
 # DROP COLUMN action with explicit drop behaviour of default CASCADE
 >ALTER TABLE t1 DROP COLUMN b CASCADE;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: DROP COLUMN b CASCADE
+  - type: ALTER_TABLE
+    table_name: t1
+    action: DROP COLUMN b CASCADE
 # DROP COLUMN action with explicit drop behaviour of RESTRICT
 >ALTER TABLE t1 DROP COLUMN b RESTRICT;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: DROP COLUMN b RESTRICT
+  - type: ALTER_TABLE
+    table_name: t1
+    action: DROP COLUMN b RESTRICT
 # ADD CONSTRAINT action with UNIQUE constraint
 >ALTER TABLE t1 ADD UNIQUE (b, c);
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ADD UNIQUE (b,c)
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ADD UNIQUE (b,c)
 # ADD CONSTRAINT action with UNIQUE constraint with constraint name
 >ALTER TABLE t1 ADD CONSTRAINT u_bc UNIQUE (b, c);
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ADD CONSTRAINT u_bc UNIQUE (b,c)
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ADD CONSTRAINT u_bc UNIQUE (b,c)
 # ADD CONSTRAINT action with PRIMARY KEY constraint
 >ALTER TABLE t1 ADD PRIMARY KEY (b, c);
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ADD PRIMARY KEY (b,c)
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ADD PRIMARY KEY (b,c)
 # ADD CONSTRAINT action with PRIMARY KEY constraint with constraint name
 >ALTER TABLE t1 ADD CONSTRAINT pk PRIMARY KEY (b, c);
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ADD CONSTRAINT pk PRIMARY KEY (b,c)
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ADD CONSTRAINT pk PRIMARY KEY (b,c)
 # ADD CONSTRAINT action with FOREIGN KEY constraint
 >ALTER TABLE t1 ADD FOREIGN KEY (t2_id) REFERENCES t2 (id);
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ADD FOREIGN KEY (t2_id) REFERENCES t2 (id)
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ADD FOREIGN KEY (t2_id) REFERENCES t2 (id)
 # ADD CONSTRAINT action with FOREIGN KEY constraint with constraint name
 >ALTER TABLE t1 ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id);
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id)
+  - type: ALTER_TABLE
+    table_name: t1
+    action: ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id)
 # DROP CONSTRAINT action no drop behaviour
 >ALTER TABLE t1 DROP CONSTRAINT b;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: DROP CONSTRAINT b CASCADE
+  - type: ALTER_TABLE
+    table_name: t1
+    action: DROP CONSTRAINT b CASCADE
 # DROP CONSTRAINT action with explicit drop behaviour of default CASCADE
 >ALTER TABLE t1 DROP CONSTRAINT b CASCADE;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: DROP CONSTRAINT b CASCADE
+  - type: ALTER_TABLE
+    table_name: t1
+    action: DROP CONSTRAINT b CASCADE
 # DROP CONSTRAINT action with explicit drop behaviour of RESTRICT
 >ALTER TABLE t1 DROP CONSTRAINT b RESTRICT;
 statements:
-- type: ALTER_TABLE
-  table_name: t1
-  action: DROP CONSTRAINT b RESTRICT
+  - type: ALTER_TABLE
+    table_name: t1
+    action: DROP CONSTRAINT b RESTRICT

--- a/tests/grammar/ansi-92/case-expressions.test
+++ b/tests/grammar/ansi-92/case-expressions.test
@@ -13,88 +13,88 @@ SELECT COALESCE()
 # COALESCE with 2 args
 >SELECT COALESCE(a, 'n/a') FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - coalesce[column-reference[a],literal['n/a']]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - coalesce[column-reference[a],literal['n/a']]
+    referenced_tables:
+      - t1
 # COALESCE with 4 args
 >SELECT COALESCE(a, b, c, 'n/a') FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - coalesce[column-reference[a],column-reference[b],column-reference[c],literal['n/a']]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - coalesce[column-reference[a],column-reference[b],column-reference[c],literal['n/a']]
+    referenced_tables:
+      - t1
 # NULLIF with 2 args
 >SELECT NULLIF(a, 'n/a') FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - nullif[column-reference[a],literal['n/a']]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - nullif[column-reference[a],literal['n/a']]
+    referenced_tables:
+      - t1
 # Simple CASE expression single WHEN no ELSE
 >SELECT CASE a WHEN 1 THEN 2 END FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2]]
+    referenced_tables:
+      - t1
 # Simple CASE expression multiple WHEN no ELSE
 >SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 END FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3]]
+    referenced_tables:
+      - t1
 # Simple CASE expression single WHEN with ELSE
 >SELECT CASE a WHEN 1 THEN 2 ELSE 42 END FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] ELSE literal[42]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] ELSE literal[42]]
+    referenced_tables:
+      - t1
 # Simple CASE expression multiple WHEN with ELSE
 >SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3] ELSE literal[4]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3] ELSE literal[4]]
+    referenced_tables:
+      - t1
 # Searched CASE expression single WHEN no ELSE
 >SELECT CASE WHEN a = 1 THEN 2 END FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2]]
+    referenced_tables:
+      - t1
 # Searched CASE expression multiple WHEN no ELSE
 >SELECT CASE WHEN a = 1 THEN 2 WHEN a = 2 THEN 3 END FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3]]
+    referenced_tables:
+      - t1
 # Searched CASE expression single WHEN with ELSE
 >SELECT CASE WHEN a = 1 THEN 2 ELSE 42 END FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] ELSE literal[42]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] ELSE literal[42]]
+    referenced_tables:
+      - t1
 # Searched CASE expression multiple WHEN with ELSE
 >SELECT CASE WHEN a = 1 THEN 2 WHEN a = 2 THEN 3 ELSE 4 END FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3] ELSE literal[4]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3] ELSE literal[4]]
+    referenced_tables:
+      - t1

--- a/tests/grammar/ansi-92/column-definitions.test
+++ b/tests/grammar/ansi-92/column-definitions.test
@@ -11,18 +11,18 @@
 >    i DOUBLE PRECISION
 >)
 statements:
-- type: CREATE_TABLE
-  table_name: t1
-  column_definitions:
-    a: INT
-    b: INT
-    c: SMALLINT
-    d: NUMERIC
-    e: NUMERIC
-    f: NUMERIC
-    g: FLOAT
-    h: FLOAT(24)
-    i: DOUBLE PRECISION
+  - type: CREATE_TABLE
+    table_name: t1
+    column_definitions:
+      a: INT
+      b: INT
+      c: SMALLINT
+      d: NUMERIC
+      e: NUMERIC
+      f: NUMERIC
+      g: FLOAT
+      h: FLOAT(24)
+      i: DOUBLE PRECISION
 # Character column definitions
 >CREATE TABLE t1 (
 >    a CHAR,
@@ -37,19 +37,19 @@ statements:
 >    j CHARACTER VARYING(10)
 >)
 statements:
-- type: CREATE_TABLE
-  table_name: t1
-  column_definitions:
-    a: CHAR
-    b: CHAR
-    c: CHAR(10)
-    d: CHAR(10)
-    e: VARCHAR
-    f: VARCHAR
-    g: VARCHAR
-    h: VARCHAR(10)
-    i: VARCHAR(10)
-    j: VARCHAR(10)
+  - type: CREATE_TABLE
+    table_name: t1
+    column_definitions:
+      a: CHAR
+      b: CHAR
+      c: CHAR(10)
+      d: CHAR(10)
+      e: VARCHAR
+      f: VARCHAR
+      g: VARCHAR
+      h: VARCHAR(10)
+      i: VARCHAR(10)
+      j: VARCHAR(10)
 # default descriptors of various kinds
 >CREATE TABLE t1 (
 >    a INT DEFAULT 0,
@@ -58,10 +58,10 @@ statements:
 >    d DATE DEFAULT CURRENT_DATE
 >)
 statements:
-- type: CREATE_TABLE
-  table_name: t1
-  column_definitions:
-    a: INT DEFAULT 0
-    b: INT DEFAULT -1
-    c: VARCHAR DEFAULT CURRENT_USER
-    d: DATE DEFAULT CURRENT_DATE
+  - type: CREATE_TABLE
+    table_name: t1
+    column_definitions:
+      a: INT DEFAULT 0
+      b: INT DEFAULT -1
+      c: VARCHAR DEFAULT CURRENT_USER
+      d: DATE DEFAULT CURRENT_DATE

--- a/tests/grammar/ansi-92/create-table.test
+++ b/tests/grammar/ansi-92/create-table.test
@@ -3,43 +3,43 @@
 >    a INT NOT NULL
 >)
 statements:
-- type: CREATE_TABLE
-  table_name: t1
-  column_definitions:
-    a: INT NOT NULL
+  - type: CREATE_TABLE
+    table_name: t1
+    column_definitions:
+      a: INT NOT NULL
 # PRIMARY KEY
 >CREATE TABLE t1 (
 >    a INT PRIMARY KEY
 >)
 statements:
-- type: CREATE_TABLE
-  table_name: t1
-  column_definitions:
-    a: INT PRIMARY KEY
+  - type: CREATE_TABLE
+    table_name: t1
+    column_definitions:
+      a: INT PRIMARY KEY
 # NOT NULL constraint plus PRIMARY KEY
 >CREATE TABLE t1 (
 >    a INT NOT NULL PRIMARY KEY
 >)
 statements:
-- type: CREATE_TABLE
-  table_name: t1
-  column_definitions:
-    a: INT NOT NULL PRIMARY KEY
+  - type: CREATE_TABLE
+    table_name: t1
+    column_definitions:
+      a: INT NOT NULL PRIMARY KEY
 # UNIQUE constraint on single column
 >CREATE TABLE t1 (
 >    a CHAR UNIQUE
 >)
 statements:
-- type: CREATE_TABLE
-  table_name: t1
-  column_definitions:
-    a: CHAR UNIQUE
+  - type: CREATE_TABLE
+    table_name: t1
+    column_definitions:
+      a: CHAR UNIQUE
 # NOT NULL constraint plus UNIQUE
 >CREATE TABLE t1 (
 >    a CHAR(10) NOT NULL UNIQUE
 >)
 statements:
-- type: CREATE_TABLE
-  table_name: t1
-  column_definitions:
-    a: CHAR(10) NOT NULL UNIQUE
+  - type: CREATE_TABLE
+    table_name: t1
+    column_definitions:
+      a: CHAR(10) NOT NULL UNIQUE

--- a/tests/grammar/ansi-92/create-view.test
+++ b/tests/grammar/ansi-92/create-view.test
@@ -12,49 +12,49 @@ CREATE VIEW v1 SELECT * FROM t1
               ^^^^^^^^^^^^^^^^^
 >CREATE VIEW v1 AS SELECT * FROM t1
 statements:
-- type: CREATE_VIEW
-  view_name: v1
-  query:
-    selected_columns:
-      - *
-    referenced_tables:
-      - t1
+  - type: CREATE_VIEW
+    view_name: v1
+    query:
+      selected_columns:
+        - *
+      referenced_tables:
+        - t1
 # Use the optional column list
 >CREATE VIEW v1 (a, b) AS SELECT a, b FROM t1
 statements:
-- type: CREATE_VIEW
-  view_name: v1
-  columns:
-    - a
-    - b
-  query:
-    selected_columns:
-      - column-reference[a]
-      - column-reference[b]
-    referenced_tables:
-      - t1
+  - type: CREATE_VIEW
+    view_name: v1
+    columns:
+      - a
+      - b
+    query:
+      selected_columns:
+        - column-reference[a]
+        - column-reference[b]
+      referenced_tables:
+        - t1
 # The optional WITH LOCAL CHECK OPTION clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH LOCAL CHECK OPTION
 statements:
-- type: CREATE_VIEW
-  view_name: v1
-  check_option: LOCAL
-  query:
-    selected_columns:
-      - *
-    referenced_tables:
-      - t1
+  - type: CREATE_VIEW
+    view_name: v1
+    check_option: LOCAL
+    query:
+      selected_columns:
+        - *
+      referenced_tables:
+        - t1
 # The optional WITH CASCADED CHECK OPTION clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH CASCADED CHECK OPTION
 statements:
-- type: CREATE_VIEW
-  view_name: v1
-  check_option: CASCADED
-  query:
-    selected_columns:
-      - *
-    referenced_tables:
-      - t1
+  - type: CREATE_VIEW
+    view_name: v1
+    check_option: CASCADED
+    query:
+      selected_columns:
+        - *
+      referenced_tables:
+        - t1
 # Missing either LOCAL or CASCADED for the check option clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH CHECK OPTION
 Syntax error.

--- a/tests/grammar/ansi-92/datetime-expressions.test
+++ b/tests/grammar/ansi-92/datetime-expressions.test
@@ -1,80 +1,80 @@
 # Simple datetime expression with local timezone
 >SELECT a AT LOCAL FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[column-reference[a] AT LOCAL]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[column-reference[a] AT LOCAL]
+    referenced_tables:
+      - t1
 # Simple datetime expression with specifier timezone
 >SELECT a AT TIME ZONE 'UTC' FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[column-reference[a] AT TIME ZONE 'UTC']
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[column-reference[a] AT TIME ZONE 'UTC']
+    referenced_tables:
+      - t1
 # CURRENT_DATE datetime function
 >SELECT CURRENT_DATE FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[current-date[] AT LOCAL]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[current-date[] AT LOCAL]
+    referenced_tables:
+      - t1
 # CURRENT_DATE datetime function with timezone component
 >SELECT CURRENT_DATE AT TIME ZONE 'UTC' FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[current-date[] AT TIME ZONE 'UTC']
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[current-date[] AT TIME ZONE 'UTC']
+    referenced_tables:
+      - t1
 # CURRENT_TIME datetime function with no time precision
 >SELECT CURRENT_TIME FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[current-time[] AT LOCAL]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[current-time[] AT LOCAL]
+    referenced_tables:
+      - t1
 # CURRENT_TIME datetime function with fractional time precision
 >SELECT CURRENT_TIME(3) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[current-time[3] AT LOCAL]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[current-time[3] AT LOCAL]
+    referenced_tables:
+      - t1
 # CURRENT_TIMESTAMP datetime function with no time precision
 >SELECT CURRENT_TIMESTAMP FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[current-timestamp[] AT LOCAL]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[current-timestamp[] AT LOCAL]
+    referenced_tables:
+      - t1
 # CURRENT_TIMESTAMP datetime function with fractional time precision
 >SELECT CURRENT_TIMESTAMP(3) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[current-timestamp[3] AT LOCAL]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[current-timestamp[3] AT LOCAL]
+    referenced_tables:
+      - t1
 # Add a datetime term to an interval term
 >SELECT a AT LOCAL + b YEAR TO MONTH FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[column-reference[a] AT LOCAL + column-reference[b] YEAR TO MONTH]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[column-reference[a] AT LOCAL + column-reference[b] YEAR TO MONTH]
+    referenced_tables:
+      - t1
 # Subtract an interval term from a datetime expression
 >SELECT a AT LOCAL - b DAY FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - datetime-expression[column-reference[a] AT LOCAL - column-reference[b] DAY]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - datetime-expression[column-reference[a] AT LOCAL - column-reference[b] DAY]
+    referenced_tables:
+      - t1

--- a/tests/grammar/ansi-92/delete.test
+++ b/tests/grammar/ansi-92/delete.test
@@ -1,11 +1,11 @@
 # DELETE with no WHERE condition
 >DELETE FROM t1
 statements:
-- type: DELETE
-  table_name: t1
+  - type: DELETE
+    table_name: t1
 # DELETE with simple WHERE condition with equality comparison
 >DELETE FROM t1 WHERE a = 10
 statements:
-- type: DELETE
-  table_name: t1
-  where: column-reference[a] = literal[10]
+  - type: DELETE
+    table_name: t1
+    where: column-reference[a] = literal[10]

--- a/tests/grammar/ansi-92/drop-view.test
+++ b/tests/grammar/ansi-92/drop-view.test
@@ -1,21 +1,21 @@
 # Simple DROP VIEW with no drop behaviour defaults to CASCADE
 >DROP VIEW v1
 statements:
-- type: DROP_VIEW
-  view_name: v1
-  drop_behaviour: CASCADE
+  - type: DROP_VIEW
+    view_name: v1
+    drop_behaviour: CASCADE
 # Simple DROP VIEW with explicit drop behaviour of CASCADE
 >DROP VIEW v1 CASCADE
 statements:
-- type: DROP_VIEW
-  view_name: v1
-  drop_behaviour: CASCADE
+  - type: DROP_VIEW
+    view_name: v1
+    drop_behaviour: CASCADE
 # Simple DROP VIEW with explicit drop behaviour of RESTRICT
 >DROP VIEW v1 RESTRICT
 statements:
-- type: DROP_VIEW
-  view_name: v1
-  drop_behaviour: RESTRICT
+  - type: DROP_VIEW
+    view_name: v1
+    drop_behaviour: RESTRICT
 # Syntax error missing table/view name
 >DROP VIEW
 Syntax error.

--- a/tests/grammar/ansi-92/grant.test
+++ b/tests/grammar/ansi-92/grant.test
@@ -37,71 +37,71 @@ GRANT ALL PRIVILEGES ON db TO usr WITH GRANT
 # GRANT all to a user, no grant option
 >GRANT ALL PRIVILEGES ON db TO usr
 statements:
-- type: GRANT
-  on: db
-  to: usr
-  privileges:
-    - ALL
+  - type: GRANT
+    on: db
+    to: usr
+    privileges:
+      - ALL
 # GRANT specific privileges to a user, no grant option
 >GRANT SELECT, DELETE, USAGE ON db TO usr
 statements:
-- type: GRANT
-  on: db
-  to: usr
-  privileges:
-    - SELECT
-    - DELETE
-    - USAGE
+  - type: GRANT
+    on: db
+    to: usr
+    privileges:
+      - SELECT
+      - DELETE
+      - USAGE
 # GRANT privilege with action taking columns
 >GRANT INSERT (a, b, c) ON tbl TO usr
 statements:
-- type: GRANT
-  on: tbl
-  to: usr
-  privileges:
-    - INSERT (a,b,c)
+  - type: GRANT
+    on: tbl
+    to: usr
+    privileges:
+      - INSERT (a,b,c)
 # GRANT privilege with action taking columns along with no optional columns for
 # update
 >GRANT INSERT (a, b, c), UPDATE ON tbl TO usr
 statements:
-- type: GRANT
-  on: tbl
-  to: usr
-  privileges:
-    - INSERT (a,b,c)
-    - UPDATE
+  - type: GRANT
+    on: tbl
+    to: usr
+    privileges:
+      - INSERT (a,b,c)
+      - UPDATE
 # GRANT all on domain object to a user
 >GRANT ALL PRIVILEGES ON DOMAIN dom TO usr
 statements:
-- type: GRANT
-  on: DOMAIN dom
-  to: usr
-  privileges:
-    - ALL
+  - type: GRANT
+    on: DOMAIN dom
+    to: usr
+    privileges:
+      - ALL
 # GRANT all on collation object to a user
 >GRANT ALL PRIVILEGES ON COLLATION utf8bin TO usr
 statements:
-- type: GRANT
-  on: COLLATION utf8bin
-  to: usr
-  privileges:
-    - ALL
+  - type: GRANT
+    on: COLLATION utf8bin
+    to: usr
+    privileges:
+      - ALL
 # GRANT all on characterset object to a user
 >GRANT ALL PRIVILEGES ON CHARACTER SET utf8 TO usr
 statements:
-- type: GRANT
-  on: CHARACTER SET utf8
-  to: usr
-  privileges:
-    - ALL
+  - type: GRANT
+    on: CHARACTER SET utf8
+    to: usr
+    privileges:
+      - ALL
 # GRANT all on translation object to a user
 >GRANT ALL PRIVILEGES ON TRANSLATION trns TO usr
 statements:
-- type: GRANT
-  on: TRANSLATION trns
-  to: usr
-  privileges:
-    - ALL
+  - type: GRANT
+    on: TRANSLATION trns
+    to: usr
+    privileges:
+      - ALL
 # Syntax error expecting SET after CHARACTER
 >GRANT ALL PRIVILEGES ON CHARACTER utf8 TO usr
 Syntax error.

--- a/tests/grammar/ansi-92/identifiers.test
+++ b/tests/grammar/ansi-92/identifiers.test
@@ -1,40 +1,40 @@
 # Simple identifier all alphanumeric
 >SELECT * FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
 # Identifier includes an underscore
 >SELECT * FROM t1_backup
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1_backup
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1_backup
 # Identifier includes a period
 >SELECT * FROM s1.t1
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - s1.t1
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - s1.t1
 # Identifier includes multiple periods and underscore
 >SELECT * FROM c1.s1.t1_backup
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - c1.s1.t1_backup
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - c1.s1.t1_backup
 # Identifier includes a prefix and a star projection
 >SELECT t1.* FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - column-reference[t1.*]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - column-reference[t1.*]
+    referenced_tables:
+      - t1

--- a/tests/grammar/ansi-92/insert-default-values.test
+++ b/tests/grammar/ansi-92/insert-default-values.test
@@ -1,6 +1,6 @@
 >INSERT INTO t1 DEFAULT VALUES
 statements:
-- type: INSERT
-  table_name: t1
-  default_columns: true
-  default_values: true
+  - type: INSERT
+    table_name: t1
+    default_columns: true
+    default_values: true

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -1,56 +1,56 @@
 >INSERT INTO t1 (a, b) VALUES (1, 2)
 statements:
-- type: INSERT
-  table_name: t1
-  columns:
-    - a
-    - b
-  values:
-    - literal[1]
-    - literal[2]
+  - type: INSERT
+    table_name: t1
+    columns:
+      - a
+      - b
+    values:
+      - literal[1]
+      - literal[2]
 # INSERT INTO with a default columns list
 >INSERT INTO t1 VALUES (1, 2)
 statements:
-- type: INSERT
-  table_name: t1
-  default_columns: true
-  values:
-    - literal[1]
-    - literal[2]
+  - type: INSERT
+    table_name: t1
+    default_columns: true
+    values:
+      - literal[1]
+      - literal[2]
 # INSERT INTO using a character values expression
 >INSERT INTO t1 VALUES ('a' COLLATE utf8bin)
 statements:
-- type: INSERT
-  table_name: t1
-  default_columns: true
-  values:
-    - literal['a'] COLLATE utf8bin
+  - type: INSERT
+    table_name: t1
+    default_columns: true
+    values:
+      - literal['a'] COLLATE utf8bin
 # INSERT INTO using datetime value expressions
 >INSERT INTO t1 (create_date, my_date) VALUES (CURRENT_DATE, '2001-01-01' AT TIME ZONE 'UTC')
 statements:
-- type: INSERT
-  table_name: t1
-  columns:
-    - create_date
-    - my_date
-  values:
-    - datetime-expression[current-date[] AT LOCAL]
-    - datetime-expression[literal['2001-01-01'] AT TIME ZONE 'UTC']
+  - type: INSERT
+    table_name: t1
+    columns:
+      - create_date
+      - my_date
+    values:
+      - datetime-expression[current-date[] AT LOCAL]
+      - datetime-expression[literal['2001-01-01'] AT TIME ZONE 'UTC']
 # INSERT INTO using interval value expressions
 >INSERT INTO t1 (num_seconds) VALUES ('2001-01-01' DAY TO SECOND)
 statements:
-- type: INSERT
-  table_name: t1
-  columns:
-    - num_seconds
-  values:
-    - interval-expression[literal['2001-01-01'] DAY TO SECOND]
+  - type: INSERT
+    table_name: t1
+    columns:
+      - num_seconds
+    values:
+      - interval-expression[literal['2001-01-01'] DAY TO SECOND]
 # INSERT INTO using numeric value expressions
 >INSERT INTO t1 (num_seconds) VALUES (1 + (2 * 3))
 statements:
-- type: INSERT
-  table_name: t1
-  columns:
-    - num_seconds
-  values:
-    - numeric-expression[literal[1] + (numeric-expression[literal[2] * literal[3]])]
+  - type: INSERT
+    table_name: t1
+    columns:
+      - num_seconds
+    values:
+      - numeric-expression[literal[1] + (numeric-expression[literal[2] * literal[3]])]

--- a/tests/grammar/ansi-92/interval-expressions.test
+++ b/tests/grammar/ansi-92/interval-expressions.test
@@ -1,83 +1,83 @@
 # Simple interval value expression with non-second interval qualifier
 >SELECT a YEAR FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] YEAR]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] YEAR]
+    referenced_tables:
+      - t1
 # Simple interval value expression with non-second interval qualifier with a
 # leading precision
 >SELECT a DAY(2) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] DAY(2)]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] DAY(2)]
+    referenced_tables:
+      - t1
 # Simple interval value expression with second interval qualifier with a
 # leading precision and no fractional precision
 >SELECT a SECOND(2) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] SECOND(2)]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] SECOND(2)]
+    referenced_tables:
+      - t1
 # Simple interval value expression with second interval qualifier with a
 # leading precision and no fractional precision
 >SELECT a SECOND(2, 5) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] SECOND(2, 5)]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] SECOND(2, 5)]
+    referenced_tables:
+      - t1
 # interval value expression with start and end non-second interval qualifier
 # with no precision specifiers
 >SELECT a YEAR TO MONTH FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] YEAR TO MONTH]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] YEAR TO MONTH]
+    referenced_tables:
+      - t1
 # interval value expression with start non-second and end second interval
 # qualifier with no precision specifiers
 >SELECT a DAY TO SECOND FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] DAY TO SECOND]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] DAY TO SECOND]
+    referenced_tables:
+      - t1
 # interval value expression with start non-second and end second interval
 # qualifier with a second fractional precision specifier
 >SELECT a DAY TO SECOND(5) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] DAY TO SECOND(0, 5)]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] DAY TO SECOND(0, 5)]
+    referenced_tables:
+      - t1
 # interval value expression that operates on an interval term with a numeric
 # factor
 >SELECT a YEAR * 12, a YEAR / 2, a MONTH / (12 / b) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] YEAR * literal[12]]
-    - interval-expression[column-reference[a] YEAR / literal[2]]
-    - interval-expression[column-reference[a] MONTH / (numeric-expression[literal[12] / column-reference[b]])]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] YEAR * literal[12]]
+      - interval-expression[column-reference[a] YEAR / literal[2]]
+      - interval-expression[column-reference[a] MONTH / (numeric-expression[literal[12] / column-reference[b]])]
+    referenced_tables:
+      - t1
 # interval value expression that uses addition and subtraction operators on
 # interval terms
 >SELECT a YEAR + 12 YEAR, created_on DAY TO SECOND - updated_on DAY TO SECOND from t1
 statements:
-- type: SELECT
-  selected_columns:
-    - interval-expression[column-reference[a] YEAR + literal[12] YEAR]
-    - interval-expression[column-reference[created_on] DAY TO SECOND - column-reference[updated_on] DAY TO SECOND]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - interval-expression[column-reference[a] YEAR + literal[12] YEAR]
+      - interval-expression[column-reference[created_on] DAY TO SECOND - column-reference[updated_on] DAY TO SECOND]
+    referenced_tables:
+      - t1

--- a/tests/grammar/ansi-92/joins.test
+++ b/tests/grammar/ansi-92/joins.test
@@ -7,104 +7,104 @@ SELECT * FROM t1 CROSS t2
 # CROSS JOIN two normal tables
 >SELECT * FROM t1 CROSS JOIN t2
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - cross-join[t1,t2]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - cross-join[t1,t2]
 # INNER JOIN two normal tables WITHOUT the INNER symbol
 >SELECT * FROM t1 JOIN t2 ON t1.id = t2.t1_id
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # INNER JOIN two normal tables WITH the INNER symbol
 >SELECT * FROM t1 INNER JOIN t2 ON t1.id = t2.t1_id
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # INNER JOIN two normal tables with no join condition
 >SELECT * FROM t1 JOIN t2
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - inner-join[t1,t2]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - inner-join[t1,t2]
 # LEFT JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.t1_id
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # LEFT JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # RIGHT JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 RIGHT JOIN t2 ON t1.id = t2.t1_id
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # RIGHT JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # FULL OUTER JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 FULL JOIN t2 ON t1.id = t2.t1_id
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # FULL OUTER JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # JOIN with USING clause
 >SELECT * FROM t1 JOIN t2 USING (id)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - inner-join[t1,t2,using[id]]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - inner-join[t1,t2,using[id]]
 # NATURAL JOIN
 >SELECT * FROM t1 NATURAL JOIN t2
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - natural-join[t1,t2]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - natural-join[t1,t2]
 # UNION JOIN of two tables
 >SELECT * FROM t1 UNION JOIN t2
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - union-join[t1,t2]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - union-join[t1,t2]

--- a/tests/grammar/ansi-92/numeric-expressions.test
+++ b/tests/grammar/ansi-92/numeric-expressions.test
@@ -1,148 +1,148 @@
 # unsigned literal number value expression primary
 >SELECT 1 FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - literal[1]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - literal[1]
+    referenced_tables:
+      - t1
 # Simple addition of literal number to column reference
 >UPDATE t1 SET x = 1 WHERE a = (2 + b)
 statements:
-- type: UPDATE
-  table_name: t1
-  set_columns:
-    x: literal[1]
-  where: column-reference[a] = (numeric-expression[literal[2] + column-reference[b]])
+  - type: UPDATE
+    table_name: t1
+    set_columns:
+      x: literal[1]
+    where: column-reference[a] = (numeric-expression[literal[2] + column-reference[b]])
 # Simple subtraction of literal number from column reference
 >UPDATE t1 SET x = 1 WHERE a = (b - 2)
 statements:
-- type: UPDATE
-  table_name: t1
-  set_columns:
-    x: literal[1]
-  where: column-reference[a] = (numeric-expression[column-reference[b] - literal[2]])
+  - type: UPDATE
+    table_name: t1
+    set_columns:
+      x: literal[1]
+    where: column-reference[a] = (numeric-expression[column-reference[b] - literal[2]])
 # Simple multiplication of two literals
 >UPDATE t1 SET x = 1 WHERE a = (2 * 1)
 statements:
-- type: UPDATE
-  table_name: t1
-  set_columns:
-    x: literal[1]
-  where: column-reference[a] = (numeric-expression[literal[2] * literal[1]])
+  - type: UPDATE
+    table_name: t1
+    set_columns:
+      x: literal[1]
+    where: column-reference[a] = (numeric-expression[literal[2] * literal[1]])
 # Simple division of two literals
 >UPDATE t1 SET x = 1 WHERE a = (1 / 2)
 statements:
-- type: UPDATE
-  table_name: t1
-  set_columns:
-    x: literal[1]
-  where: column-reference[a] = (numeric-expression[literal[1] / literal[2]])
+  - type: UPDATE
+    table_name: t1
+    set_columns:
+      x: literal[1]
+    where: column-reference[a] = (numeric-expression[literal[1] / literal[2]])
 # Addition of numeric expression to a literal
 >UPDATE t1 SET x = 1 WHERE a = (1 + (2 * 1))
 statements:
-- type: UPDATE
-  table_name: t1
-  set_columns:
-    x: literal[1]
-  where: column-reference[a] = (numeric-expression[literal[1] + (numeric-expression[literal[2] * literal[1]])])
+  - type: UPDATE
+    table_name: t1
+    set_columns:
+      x: literal[1]
+    where: column-reference[a] = (numeric-expression[literal[1] + (numeric-expression[literal[2] * literal[1]])])
 # General value expression primaries
 >SELECT USER, CURRENT_USER, SESSION_USER, SYSTEM_USER, VALUE FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - USER
-    - CURRENT_USER
-    - SESSION_USER
-    - SYSTEM_USER
-    - VALUE
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - USER
+      - CURRENT_USER
+      - SESSION_USER
+      - SYSTEM_USER
+      - VALUE
+    referenced_tables:
+      - t1
 # COUNT set function specifications
 >SELECT COUNT(*), COUNT(DISTINCT a), COUNT(a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - COUNT(*)
-    - COUNT(DISTINCT column-reference[a])
-    - COUNT(column-reference[a])
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - COUNT(*)
+      - COUNT(DISTINCT column-reference[a])
+      - COUNT(column-reference[a])
+    referenced_tables:
+      - t1
 # SUM set function specifications
 >SELECT SUM(DISTINCT a), SUM(a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - SUM(DISTINCT column-reference[a])
-    - SUM(column-reference[a])
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - SUM(DISTINCT column-reference[a])
+      - SUM(column-reference[a])
+    referenced_tables:
+      - t1
 # AVG set function specifications
 >SELECT AVG(DISTINCT a), AVG(a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - AVG(DISTINCT column-reference[a])
-    - AVG(column-reference[a])
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - AVG(DISTINCT column-reference[a])
+      - AVG(column-reference[a])
+    referenced_tables:
+      - t1
 # MIN set function specifications
 >SELECT MIN(DISTINCT a), MIN(a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - MIN(DISTINCT column-reference[a])
-    - MIN(column-reference[a])
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - MIN(DISTINCT column-reference[a])
+      - MIN(column-reference[a])
+    referenced_tables:
+      - t1
 # MAX set function specifications
 >SELECT MAX(DISTINCT a), MAX(a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - MAX(DISTINCT column-reference[a])
-    - MAX(column-reference[a])
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - MAX(DISTINCT column-reference[a])
+      - MAX(column-reference[a])
+    referenced_tables:
+      - t1
 # Nested set function specifications
 >SELECT MAX(COUNT(a)) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - MAX(COUNT(column-reference[a]))
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - MAX(COUNT(column-reference[a]))
+    referenced_tables:
+      - t1
 # Use of CHAR_LENGTH and CHARACTER_LENGTH numeric functions
 >SELECT CHAR_LENGTH(a), CHARACTER_LENGTH(a) + 1 FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - char-length[column-reference[a]]
-    - numeric-expression[char-length[column-reference[a]] + literal[1]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - char-length[column-reference[a]]
+      - numeric-expression[char-length[column-reference[a]] + literal[1]]
+    referenced_tables:
+      - t1
 # Use of BIT_LENGTH and OCTET_LENGTH numeric functions
 >SELECT BIT_LENGTH(a), OCTET_LENGTH(a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - bit-length[column-reference[a]]
-    - octet-length[column-reference[a]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - bit-length[column-reference[a]]
+      - octet-length[column-reference[a]]
+    referenced_tables:
+      - t1
 # Use of EXTRACT numeric function
 >SELECT EXTRACT(YEAR FROM a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - extract[YEAR FROM datetime-expression[column-reference[a] AT LOCAL]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - extract[YEAR FROM datetime-expression[column-reference[a] AT LOCAL]]
+    referenced_tables:
+      - t1
 # Use of POSITION numeric function
 >SELECT POSITION('123' IN a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - position[literal['123'] IN column-reference[a]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - position[literal['123'] IN column-reference[a]]
+    referenced_tables:
+      - t1

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -7,14 +7,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[10]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[10]
 # anti-equality comparison predicate
 >SELECT * FROM t1 WHERE a <> 10
 statements:
@@ -24,14 +28,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: NOT_EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[10]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: NOT_EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[10]
 # Order of value expressions should not matter in equality comparison
 >SELECT * FROM t1 WHERE 10 = a
 statements:
@@ -41,14 +49,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: literal[10]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[10]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
 # Compound predicate with AND of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 AND b = 2
 statements:
@@ -58,23 +70,29 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[1]
-        and:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[b]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: literal[2]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[1]
+            and:
+              factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    element_type: VALUE_EXPRESSION
+                    value: column-reference[b]
+                  right:
+                    element_type: VALUE_EXPRESSION
+                    value: literal[2]
 # Compound predicate with OR of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 OR b = 2
 statements:
@@ -84,22 +102,28 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[1]
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[b]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[2]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[1]
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[b]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[2]
 # Compound predicate with both AND and OR operators
 >SELECT * FROM t1 WHERE a = 1 AND b = 2 OR c = 3
 statements:
@@ -109,31 +133,39 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[1]
-        and:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[b]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: literal[2]
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[c]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[3]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[1]
+            and:
+              factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    element_type: VALUE_EXPRESSION
+                    value: column-reference[b]
+                  right:
+                    element_type: VALUE_EXPRESSION
+                    value: literal[2]
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[c]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[3]
 # Compound predicate with both OR and AND operators. The AND should take
 # precedence
 >SELECT * FROM t1 WHERE a = 1 OR b = 2 AND c = 3
@@ -144,31 +176,39 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[1]
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[b]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[2]
-        and:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[c]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: literal[3]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[1]
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[b]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[2]
+            and:
+              factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    element_type: VALUE_EXPRESSION
+                    value: column-reference[c]
+                  right:
+                    element_type: VALUE_EXPRESSION
+                    value: literal[3]
 # Compound predicate with both AND and OR operators using parens for precedence
 # override
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3)
@@ -179,31 +219,42 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[1]
-        and:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[b]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: literal[2]
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[c]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: literal[3]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[1]
+            and:
+              factor:
+                search_condition:
+                  terms:
+                    - factor:
+                        predicate:
+                          type: COMPARISON
+                          op: EQUAL
+                          left:
+                            element_type: VALUE_EXPRESSION
+                            value: column-reference[b]
+                          right:
+                            element_type: VALUE_EXPRESSION
+                            value: literal[2]
+                    - factor:
+                        predicate:
+                          type: COMPARISON
+                          op: EQUAL
+                          left:
+                            element_type: VALUE_EXPRESSION
+                            value: column-reference[c]
+                          right:
+                            element_type: VALUE_EXPRESSION
+                            value: literal[3]
 # Multiple nested search conditions using parens for precedence
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3 AND (d = 4 OR e = 5))
 statements:
@@ -213,48 +264,66 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: literal[1]
-        and:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[b]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: literal[2]
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[c]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: literal[3]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[1]
             and:
-              - predicate_type: COMPARISON
-                op: EQUAL
-                left:
-                  element_type: VALUE_EXPRESSION
-                  value: column-reference[d]
-                right:
-                  element_type: VALUE_EXPRESSION
-                  value: literal[4]
-              - predicate_type: COMPARISON
-                op: EQUAL
-                left:
-                  element_type: VALUE_EXPRESSION
-                  value: column-reference[e]
-                right:
-                  element_type: VALUE_EXPRESSION
-                  value: literal[5]
+              factor:
+                search_condition:
+                  terms:
+                    - factor:
+                        predicate:
+                          type: COMPARISON
+                          op: EQUAL
+                          left:
+                            element_type: VALUE_EXPRESSION
+                            value: column-reference[b]
+                          right:
+                            element_type: VALUE_EXPRESSION
+                            value: literal[2]
+                    - factor:
+                        predicate:
+                          type: COMPARISON
+                          op: EQUAL
+                          left:
+                            element_type: VALUE_EXPRESSION
+                            value: column-reference[c]
+                          right:
+                            element_type: VALUE_EXPRESSION
+                            value: literal[3]
+                      and:
+                        factor:
+                          search_condition:
+                            terms:
+                              - factor:
+                                  predicate:
+                                    type: COMPARISON
+                                    op: EQUAL
+                                    left:
+                                      element_type: VALUE_EXPRESSION
+                                      value: column-reference[d]
+                                    right:
+                                      element_type: VALUE_EXPRESSION
+                                      value: literal[4]
+                              - factor:
+                                  predicate:
+                                    type: COMPARISON
+                                    op: EQUAL
+                                    left:
+                                      element_type: VALUE_EXPRESSION
+                                      value: column-reference[e]
+                                    right:
+                                      element_type: VALUE_EXPRESSION
+                                      value: literal[5]
 # IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE a IN (1)
 statements:
@@ -264,12 +333,16 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: IN_VALUES
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        values:
-          - literal[1]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: IN_VALUES
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                values:
+                  - literal[1]
 # Negate of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE a NOT IN (1)
 statements:
@@ -279,13 +352,17 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: IN_VALUES
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        predicate_negate: true
-        values:
-          - literal[1]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: IN_VALUES
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                negate: true
+                values:
+                  - literal[1]
 # top-level negation of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE NOT a IN (1)
 statements:
@@ -295,13 +372,17 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: IN_VALUES
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        values:
-          - literal[1]
-        factor_negate: true
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: IN_VALUES
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                values:
+                  - literal[1]
+              negate: true
 # double-negation of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE NOT a NOT IN (1)
 statements:
@@ -311,14 +392,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: IN_VALUES
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        predicate_negate: true
-        values:
-          - literal[1]
-        factor_negate: true
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: IN_VALUES
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                negate: true
+                values:
+                  - literal[1]
+              negate: true
 # IN (<value list>) operator with multiple value
 >SELECT * FROM t1 WHERE a IN (1, 2, 3)
 statements:
@@ -328,14 +413,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: IN_VALUES
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        values:
-          - literal[1]
-          - literal[2]
-          - literal[3]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: IN_VALUES
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                values:
+                  - literal[1]
+                  - literal[2]
+                  - literal[3]
 # IN (<value list>) operator with complex value expressions
 >SELECT * FROM t1 WHERE a IN (1 - b, CHAR_LENGTH(b))
 statements:
@@ -345,13 +434,17 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: IN_VALUES
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        values:
-          - numeric-expression[literal[1] - column-reference[b]]
-          - char-length[column-reference[b]]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: IN_VALUES
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                values:
+                  - numeric-expression[literal[1] - column-reference[b]]
+                  - char-length[column-reference[b]]
 # IN (<subquery>) operator
 >SELECT * FROM t1 WHERE a IN (SELECT t1_a FROM t2)
 statements:
@@ -361,15 +454,19 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: IN_SUBQUERY
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        query:
-          selected_columns:
-            - column-reference[t1_a]
-          referenced_tables:
-            - t2
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: IN_SUBQUERY
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                query:
+                  selected_columns:
+                    - column-reference[t1_a]
+                  referenced_tables:
+                    - t2
 # EXISTS (<subquery>) predicate
 >SELECT * FROM t1 WHERE EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -379,21 +476,29 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: EXISTS
-        query:
-          selected_columns:
-            - column-reference[t1_id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: EXISTS
+                query:
+                  selected_columns:
+                    - column-reference[t1_id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
 # NOT EXISTS (<subquery>) predicate
 >SELECT * FROM t1 WHERE NOT EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -403,22 +508,30 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: EXISTS
-        query:
-          selected_columns:
-            - column-reference[t1_id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
-        factor_negate: true
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: EXISTS
+                query:
+                  selected_columns:
+                    - column-reference[t1_id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
+                negate: true
 # <row> MATCH (<subquery>) predicate
 >SELECT * FROM t1 WHERE id MATCH (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -428,24 +541,32 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: MATCH
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[id]
-        query:
-          selected_columns:
-            - column-reference[t1_id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: MATCH
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[id]
+                query:
+                  selected_columns:
+                    - column-reference[t1_id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate explicit FULL
 >SELECT * FROM t1 WHERE id MATCH FULL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -455,24 +576,32 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: MATCH
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[id]
-        query:
-          selected_columns:
-            - column-reference[t1_id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: MATCH
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[id]
+                query:
+                  selected_columns:
+                    - column-reference[t1_id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate with UNIQUE
 >SELECT * FROM t1 WHERE id MATCH UNIQUE (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -482,25 +611,33 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: MATCH
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[id]
-        unique: true
-        query:
-          selected_columns:
-            - column-reference[t1_id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: MATCH
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[id]
+                unique: true
+                query:
+                  selected_columns:
+                    - column-reference[t1_id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
 # <row> MATCH (<subquery>) predicate explicit PARTIAL
 >SELECT * FROM t1 WHERE id MATCH PARTIAL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -510,25 +647,33 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: MATCH
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[id]
-        partial: true
-        query:
-          selected_columns:
-            - column-reference[t1_id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: MATCH
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[id]
+                partial: true
+                query:
+                  selected_columns:
+                    - column-reference[t1_id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
 # LIKE predicate with simple column comparison with string
 >SELECT * FROM t1 WHERE a LIKE 's%'
 statements:
@@ -538,11 +683,15 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: LIKE
-        match:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        pattern: literal['s%']
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: LIKE
+                match:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                pattern: literal['s%']
 # LIKE predicate with concatenated column comparison with string
 >SELECT * FROM t1 WHERE a LIKE b || '%'
 statements:
@@ -552,11 +701,15 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: LIKE
-        match:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        pattern: concatenate[column-reference[b], literal['%']]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: LIKE
+                match:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                pattern: concatenate[column-reference[b], literal['%']]
 # OVERLAPS predicate with date columns from multiple tables
 >SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
 statements:
@@ -567,17 +720,21 @@ statements:
       - t1
       - t2
     where:
-      - predicate_type: OVERLAPS
-        left:
-          - element_type: VALUE_EXPRESSION
-            value: column-reference[t1.start]
-          - element_type: VALUE_EXPRESSION
-            value: column-reference[t1.end]
-        right:
-          - element_type: VALUE_EXPRESSION
-            value: column-reference[t2.start]
-          - element_type: VALUE_EXPRESSION
-            value: column-reference[t2.end]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: OVERLAPS
+                left:
+                  - element_type: VALUE_EXPRESSION
+                    value: column-reference[t1.start]
+                  - element_type: VALUE_EXPRESSION
+                    value: column-reference[t1.end]
+                right:
+                  - element_type: VALUE_EXPRESSION
+                    value: column-reference[t2.start]
+                  - element_type: VALUE_EXPRESSION
+                    value: column-reference[t2.end]
 # the UNIQUE predicate returns a match when the correlation returns one and
 # only one row
 >SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
@@ -588,21 +745,29 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: UNIQUE
-        query:
-          selected_columns:
-            - column-reference[t2.id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t2.t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: UNIQUE
+                query:
+                  selected_columns:
+                    - column-reference[t2.id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t2.t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
 # negated UNIQUE predicate
 >SELECT * FROM t1 WHERE NOT UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
 statements:
@@ -612,22 +777,30 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: UNIQUE
-        query:
-          selected_columns:
-            - column-reference[t2.id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t2.t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
-        factor_negate: true
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: UNIQUE
+                query:
+                  selected_columns:
+                    - column-reference[t2.id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t2.t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
+                negate: true
 # Combine EXISTS and UNIQUE predicate
 >SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id) AND EXISTS (SELECT t3.id FROM t3 WHERE t3.t1_id = t1.id);
 statements:
@@ -637,37 +810,51 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: UNIQUE
-        query:
-          selected_columns:
-            - column-reference[t2.id]
-          referenced_tables:
-            - t2
-          where:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t2.t1_id]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[t1.id]
-        and:
-          - predicate_type: EXISTS
-            query:
-              selected_columns:
-                - column-reference[t3.id]
-              referenced_tables:
-                - t3
-              where:
-                - predicate_type: COMPARISON
-                  op: EQUAL
-                  left:
-                    element_type: VALUE_EXPRESSION
-                    value: column-reference[t3.t1_id]
-                  right:
-                    element_type: VALUE_EXPRESSION
-                    value: column-reference[t1.id]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: UNIQUE
+                query:
+                  selected_columns:
+                    - column-reference[t2.id]
+                  referenced_tables:
+                    - t2
+                  where:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t2.t1_id]
+                              right:
+                                element_type: VALUE_EXPRESSION
+                                value: column-reference[t1.id]
+              and:
+                factor:
+                  predicate:
+                    type: EXISTS
+                    query:
+                      selected_columns:
+                        - column-reference[t3.id]
+                      referenced_tables:
+                        - t3
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    element_type: VALUE_EXPRESSION
+                                    value: column-reference[t3.t1_id]
+                                  right:
+                                    element_type: VALUE_EXPRESSION
+                                    value: column-reference[t1.id]
 # quantified comparison predicates are like comparison predicates with an
 # ANY|ALL|SOME quantifier
 >SELECT * FROM t1 WHERE t1.start > ALL (SELECT t2.start FROM t2)
@@ -678,17 +865,21 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: QUANTIFIED_COMPARISON
-        op: GREATER_THAN
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[t1.start]
-        quantifier: ALL
-        query:
-          selected_columns:
-            - column-reference[t2.start]
-          referenced_tables:
-            - t2
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: QUANTIFIED_COMPARISON
+                op: GREATER_THAN
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[t1.start]
+                quantifier: ALL
+                query:
+                  selected_columns:
+                    - column-reference[t2.start]
+                  referenced_tables:
+                    - t2
 # quantified comparison predicate with ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= ANY (SELECT t2.start FROM t2)
 statements:
@@ -698,17 +889,21 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: QUANTIFIED_COMPARISON
-        op: LESS_THAN_OR_EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[t1.start]
-        quantifier: ANY
-        query:
-          selected_columns:
-            - column-reference[t2.start]
-          referenced_tables:
-            - t2
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: QUANTIFIED_COMPARISON
+                op: LESS_THAN_OR_EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[t1.start]
+                quantifier: ANY
+                query:
+                  selected_columns:
+                    - column-reference[t2.start]
+                  referenced_tables:
+                    - t2
 # quantified comparison predicate with SOME quantifier translated to ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= SOME (SELECT t2.start FROM t2)
 statements:
@@ -718,14 +913,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: QUANTIFIED_COMPARISON
-        op: LESS_THAN_OR_EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[t1.start]
-        quantifier: ANY
-        query:
-          selected_columns:
-            - column-reference[t2.start]
-          referenced_tables:
-            - t2
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: QUANTIFIED_COMPARISON
+                op: LESS_THAN_OR_EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[t1.start]
+                quantifier: ANY
+                query:
+                  selected_columns:
+                    - column-reference[t2.start]
+                  referenced_tables:
+                    - t2

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -1,731 +1,731 @@
 # simple equality comparison predicate
 >SELECT * FROM t1 WHERE a = 10
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[10]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[10]
 # anti-equality comparison predicate
 >SELECT * FROM t1 WHERE a <> 10
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: NOT_EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[10]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: NOT_EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[10]
 # Order of value expressions should not matter in equality comparison
 >SELECT * FROM t1 WHERE 10 = a
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: literal[10]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: literal[10]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
 # Compound predicate with AND of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 AND b = 2
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[1]
-      and:
-        - predicate_type: COMPARISON
-          op: EQUAL
-          left:
-            element_type: VALUE_EXPRESSION
-            value: column-reference[b]
-          right:
-            element_type: VALUE_EXPRESSION
-            value: literal[2]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[1]
+        and:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[b]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: literal[2]
 # Compound predicate with OR of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 OR b = 2
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[1]
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[b]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[2]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[1]
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[b]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[2]
 # Compound predicate with both AND and OR operators
 >SELECT * FROM t1 WHERE a = 1 AND b = 2 OR c = 3
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[1]
-      and:
-        - predicate_type: COMPARISON
-          op: EQUAL
-          left:
-            element_type: VALUE_EXPRESSION
-            value: column-reference[b]
-          right:
-            element_type: VALUE_EXPRESSION
-            value: literal[2]
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[c]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[3]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[1]
+        and:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[b]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: literal[2]
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[c]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[3]
 # Compound predicate with both OR and AND operators. The AND should take
 # precedence
 >SELECT * FROM t1 WHERE a = 1 OR b = 2 AND c = 3
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[1]
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[b]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[2]
-      and:
-        - predicate_type: COMPARISON
-          op: EQUAL
-          left:
-            element_type: VALUE_EXPRESSION
-            value: column-reference[c]
-          right:
-            element_type: VALUE_EXPRESSION
-            value: literal[3]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[1]
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[b]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[2]
+        and:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[c]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: literal[3]
 # Compound predicate with both AND and OR operators using parens for precedence
 # override
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[1]
-      and:
-        - predicate_type: COMPARISON
-          op: EQUAL
-          left:
-            element_type: VALUE_EXPRESSION
-            value: column-reference[b]
-          right:
-            element_type: VALUE_EXPRESSION
-            value: literal[2]
-        - predicate_type: COMPARISON
-          op: EQUAL
-          left:
-            element_type: VALUE_EXPRESSION
-            value: column-reference[c]
-          right:
-            element_type: VALUE_EXPRESSION
-            value: literal[3]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[1]
+        and:
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[b]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: literal[2]
+          - predicate_type: COMPARISON
+            op: EQUAL
+            left:
+              element_type: VALUE_EXPRESSION
+              value: column-reference[c]
+            right:
+              element_type: VALUE_EXPRESSION
+              value: literal[3]
 # Multiple nested search conditions using parens for precedence
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3 AND (d = 4 OR e = 5))
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: literal[1]
-      and:
-        - predicate_type: COMPARISON
-          op: EQUAL
-          left:
-            element_type: VALUE_EXPRESSION
-            value: column-reference[b]
-          right:
-            element_type: VALUE_EXPRESSION
-            value: literal[2]
-        - predicate_type: COMPARISON
-          op: EQUAL
-          left:
-            element_type: VALUE_EXPRESSION
-            value: column-reference[c]
-          right:
-            element_type: VALUE_EXPRESSION
-            value: literal[3]
-          and:
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[d]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: literal[4]
-            - predicate_type: COMPARISON
-              op: EQUAL
-              left:
-                element_type: VALUE_EXPRESSION
-                value: column-reference[e]
-              right:
-                element_type: VALUE_EXPRESSION
-                value: literal[5]
-# IN (<value list>) operator with single value
->SELECT * FROM t1 WHERE a IN (1)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: IN_VALUES
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      values:
-        - literal[1]
-# Negate of IN (<value list>) operator with single value
->SELECT * FROM t1 WHERE a NOT IN (1)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: IN_VALUES
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      predicate_negate: true
-      values:
-        - literal[1]
-# top-level negation of IN (<value list>) operator with single value
->SELECT * FROM t1 WHERE NOT a IN (1)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: IN_VALUES
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      values:
-        - literal[1]
-      factor_negate: true
-# double-negation of IN (<value list>) operator with single value
->SELECT * FROM t1 WHERE NOT a NOT IN (1)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: IN_VALUES
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      predicate_negate: true
-      values:
-        - literal[1]
-      factor_negate: true
-# IN (<value list>) operator with multiple value
->SELECT * FROM t1 WHERE a IN (1, 2, 3)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: IN_VALUES
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      values:
-        - literal[1]
-        - literal[2]
-        - literal[3]
-# IN (<value list>) operator with complex value expressions
->SELECT * FROM t1 WHERE a IN (1 - b, CHAR_LENGTH(b))
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: IN_VALUES
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      values:
-        - numeric-expression[literal[1] - column-reference[b]]
-        - char-length[column-reference[b]]
-# IN (<subquery>) operator
->SELECT * FROM t1 WHERE a IN (SELECT t1_a FROM t2)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: IN_SUBQUERY
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      query:
-        selected_columns:
-          - column-reference[t1_a]
-        referenced_tables:
-          - t2
-# EXISTS (<subquery>) predicate
->SELECT * FROM t1 WHERE EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: EXISTS
-      query:
-        selected_columns:
-          - column-reference[t1_id]
-        referenced_tables:
-          - t2
-        where:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: literal[1]
+        and:
           - predicate_type: COMPARISON
             op: EQUAL
             left:
               element_type: VALUE_EXPRESSION
-              value: column-reference[t1_id]
+              value: column-reference[b]
             right:
               element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-# NOT EXISTS (<subquery>) predicate
->SELECT * FROM t1 WHERE NOT EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: EXISTS
-      query:
-        selected_columns:
-          - column-reference[t1_id]
-        referenced_tables:
-          - t2
-        where:
+              value: literal[2]
           - predicate_type: COMPARISON
             op: EQUAL
             left:
               element_type: VALUE_EXPRESSION
-              value: column-reference[t1_id]
+              value: column-reference[c]
             right:
               element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-      factor_negate: true
-# <row> MATCH (<subquery>) predicate
->SELECT * FROM t1 WHERE id MATCH (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: MATCH
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[id]
-      query:
-        selected_columns:
-          - column-reference[t1_id]
-        referenced_tables:
-          - t2
-        where:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1_id]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-# <row> MATCH (<subquery>) predicate explicit FULL
->SELECT * FROM t1 WHERE id MATCH FULL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: MATCH
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[id]
-      query:
-        selected_columns:
-          - column-reference[t1_id]
-        referenced_tables:
-          - t2
-        where:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1_id]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-# <row> MATCH (<subquery>) predicate with UNIQUE
->SELECT * FROM t1 WHERE id MATCH UNIQUE (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: MATCH
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[id]
-      unique: true
-      query:
-        selected_columns:
-          - column-reference[t1_id]
-        referenced_tables:
-          - t2
-        where:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1_id]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-# <row> MATCH (<subquery>) predicate explicit PARTIAL
->SELECT * FROM t1 WHERE id MATCH PARTIAL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: MATCH
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[id]
-      partial: true
-      query:
-        selected_columns:
-          - column-reference[t1_id]
-        referenced_tables:
-          - t2
-        where:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1_id]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-# LIKE predicate with simple column comparison with string
->SELECT * FROM t1 WHERE a LIKE 's%'
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: LIKE
-      match:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      pattern: literal['s%']
-# LIKE predicate with concatenated column comparison with string
->SELECT * FROM t1 WHERE a LIKE b || '%'
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: LIKE
-      match:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      pattern: concatenate[column-reference[b], literal['%']]
-# OVERLAPS predicate with date columns from multiple tables
->SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-    - t2
-  where:
-    - predicate_type: OVERLAPS
-      left:
-        - element_type: VALUE_EXPRESSION
-          value: column-reference[t1.start]
-        - element_type: VALUE_EXPRESSION
-          value: column-reference[t1.end]
-      right:
-        - element_type: VALUE_EXPRESSION
-          value: column-reference[t2.start]
-        - element_type: VALUE_EXPRESSION
-          value: column-reference[t2.end]
-# the UNIQUE predicate returns a match when the correlation returns one and
-# only one row
->SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: UNIQUE
-      query:
-        selected_columns:
-          - column-reference[t2.id]
-        referenced_tables:
-          - t2
-        where:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t2.t1_id]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-# negated UNIQUE predicate
->SELECT * FROM t1 WHERE NOT UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: UNIQUE
-      query:
-        selected_columns:
-          - column-reference[t2.id]
-        referenced_tables:
-          - t2
-        where:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t2.t1_id]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-      factor_negate: true
-# Combine EXISTS and UNIQUE predicate
->SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id) AND EXISTS (SELECT t3.id FROM t3 WHERE t3.t1_id = t1.id);
-statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: UNIQUE
-      query:
-        selected_columns:
-          - column-reference[t2.id]
-        referenced_tables:
-          - t2
-        where:
-          - predicate_type: COMPARISON
-            op: EQUAL
-            left:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t2.t1_id]
-            right:
-              element_type: VALUE_EXPRESSION
-              value: column-reference[t1.id]
-      and:
-        - predicate_type: EXISTS
-          query:
-            selected_columns:
-              - column-reference[t3.id]
-            referenced_tables:
-              - t3
-            where:
+              value: literal[3]
+            and:
               - predicate_type: COMPARISON
                 op: EQUAL
                 left:
                   element_type: VALUE_EXPRESSION
-                  value: column-reference[t3.t1_id]
+                  value: column-reference[d]
                 right:
                   element_type: VALUE_EXPRESSION
-                  value: column-reference[t1.id]
+                  value: literal[4]
+              - predicate_type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[e]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: literal[5]
+# IN (<value list>) operator with single value
+>SELECT * FROM t1 WHERE a IN (1)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: IN_VALUES
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        values:
+          - literal[1]
+# Negate of IN (<value list>) operator with single value
+>SELECT * FROM t1 WHERE a NOT IN (1)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: IN_VALUES
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        predicate_negate: true
+        values:
+          - literal[1]
+# top-level negation of IN (<value list>) operator with single value
+>SELECT * FROM t1 WHERE NOT a IN (1)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: IN_VALUES
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        values:
+          - literal[1]
+        factor_negate: true
+# double-negation of IN (<value list>) operator with single value
+>SELECT * FROM t1 WHERE NOT a NOT IN (1)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: IN_VALUES
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        predicate_negate: true
+        values:
+          - literal[1]
+        factor_negate: true
+# IN (<value list>) operator with multiple value
+>SELECT * FROM t1 WHERE a IN (1, 2, 3)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: IN_VALUES
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        values:
+          - literal[1]
+          - literal[2]
+          - literal[3]
+# IN (<value list>) operator with complex value expressions
+>SELECT * FROM t1 WHERE a IN (1 - b, CHAR_LENGTH(b))
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: IN_VALUES
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        values:
+          - numeric-expression[literal[1] - column-reference[b]]
+          - char-length[column-reference[b]]
+# IN (<subquery>) operator
+>SELECT * FROM t1 WHERE a IN (SELECT t1_a FROM t2)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: IN_SUBQUERY
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        query:
+          selected_columns:
+            - column-reference[t1_a]
+          referenced_tables:
+            - t2
+# EXISTS (<subquery>) predicate
+>SELECT * FROM t1 WHERE EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: EXISTS
+        query:
+          selected_columns:
+            - column-reference[t1_id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+# NOT EXISTS (<subquery>) predicate
+>SELECT * FROM t1 WHERE NOT EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: EXISTS
+        query:
+          selected_columns:
+            - column-reference[t1_id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+        factor_negate: true
+# <row> MATCH (<subquery>) predicate
+>SELECT * FROM t1 WHERE id MATCH (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: MATCH
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[id]
+        query:
+          selected_columns:
+            - column-reference[t1_id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+# <row> MATCH (<subquery>) predicate explicit FULL
+>SELECT * FROM t1 WHERE id MATCH FULL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: MATCH
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[id]
+        query:
+          selected_columns:
+            - column-reference[t1_id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+# <row> MATCH (<subquery>) predicate with UNIQUE
+>SELECT * FROM t1 WHERE id MATCH UNIQUE (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: MATCH
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[id]
+        unique: true
+        query:
+          selected_columns:
+            - column-reference[t1_id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+# <row> MATCH (<subquery>) predicate explicit PARTIAL
+>SELECT * FROM t1 WHERE id MATCH PARTIAL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: MATCH
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[id]
+        partial: true
+        query:
+          selected_columns:
+            - column-reference[t1_id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+# LIKE predicate with simple column comparison with string
+>SELECT * FROM t1 WHERE a LIKE 's%'
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: LIKE
+        match:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        pattern: literal['s%']
+# LIKE predicate with concatenated column comparison with string
+>SELECT * FROM t1 WHERE a LIKE b || '%'
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: LIKE
+        match:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        pattern: concatenate[column-reference[b], literal['%']]
+# OVERLAPS predicate with date columns from multiple tables
+>SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+      - t2
+    where:
+      - predicate_type: OVERLAPS
+        left:
+          - element_type: VALUE_EXPRESSION
+            value: column-reference[t1.start]
+          - element_type: VALUE_EXPRESSION
+            value: column-reference[t1.end]
+        right:
+          - element_type: VALUE_EXPRESSION
+            value: column-reference[t2.start]
+          - element_type: VALUE_EXPRESSION
+            value: column-reference[t2.end]
+# the UNIQUE predicate returns a match when the correlation returns one and
+# only one row
+>SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: UNIQUE
+        query:
+          selected_columns:
+            - column-reference[t2.id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t2.t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+# negated UNIQUE predicate
+>SELECT * FROM t1 WHERE NOT UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: UNIQUE
+        query:
+          selected_columns:
+            - column-reference[t2.id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t2.t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+        factor_negate: true
+# Combine EXISTS and UNIQUE predicate
+>SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id) AND EXISTS (SELECT t3.id FROM t3 WHERE t3.t1_id = t1.id);
+statements:
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: UNIQUE
+        query:
+          selected_columns:
+            - column-reference[t2.id]
+          referenced_tables:
+            - t2
+          where:
+            - predicate_type: COMPARISON
+              op: EQUAL
+              left:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t2.t1_id]
+              right:
+                element_type: VALUE_EXPRESSION
+                value: column-reference[t1.id]
+        and:
+          - predicate_type: EXISTS
+            query:
+              selected_columns:
+                - column-reference[t3.id]
+              referenced_tables:
+                - t3
+              where:
+                - predicate_type: COMPARISON
+                  op: EQUAL
+                  left:
+                    element_type: VALUE_EXPRESSION
+                    value: column-reference[t3.t1_id]
+                  right:
+                    element_type: VALUE_EXPRESSION
+                    value: column-reference[t1.id]
 # quantified comparison predicates are like comparison predicates with an
 # ANY|ALL|SOME quantifier
 >SELECT * FROM t1 WHERE t1.start > ALL (SELECT t2.start FROM t2)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: QUANTIFIED_COMPARISON
-      op: GREATER_THAN
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[t1.start]
-      quantifier: ALL
-      query:
-        selected_columns:
-          - column-reference[t2.start]
-        referenced_tables:
-          - t2
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: QUANTIFIED_COMPARISON
+        op: GREATER_THAN
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[t1.start]
+        quantifier: ALL
+        query:
+          selected_columns:
+            - column-reference[t2.start]
+          referenced_tables:
+            - t2
 # quantified comparison predicate with ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= ANY (SELECT t2.start FROM t2)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: QUANTIFIED_COMPARISON
-      op: LESS_THAN_OR_EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[t1.start]
-      quantifier: ANY
-      query:
-        selected_columns:
-          - column-reference[t2.start]
-        referenced_tables:
-          - t2
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: QUANTIFIED_COMPARISON
+        op: LESS_THAN_OR_EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[t1.start]
+        quantifier: ANY
+        query:
+          selected_columns:
+            - column-reference[t2.start]
+          referenced_tables:
+            - t2
 # quantified comparison predicate with SOME quantifier translated to ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= SOME (SELECT t2.start FROM t2)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: QUANTIFIED_COMPARISON
-      op: LESS_THAN_OR_EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[t1.start]
-      quantifier: ANY
-      query:
-        selected_columns:
-          - column-reference[t2.start]
-        referenced_tables:
-          - t2
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: QUANTIFIED_COMPARISON
+        op: LESS_THAN_OR_EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[t1.start]
+        quantifier: ANY
+        query:
+          selected_columns:
+            - column-reference[t2.start]
+          referenced_tables:
+            - t2

--- a/tests/grammar/ansi-92/row-value-constructors.test
+++ b/tests/grammar/ansi-92/row-value-constructors.test
@@ -2,93 +2,93 @@
 # value constructor elements
 >SELECT  * FROM t1 WHERE (a, b) = (b, a)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        - element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        - element_type: VALUE_EXPRESSION
-          value: column-reference[b]
-      right:
-        - element_type: VALUE_EXPRESSION
-          value: column-reference[b]
-        - element_type: VALUE_EXPRESSION
-          value: column-reference[a]
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          - element_type: VALUE_EXPRESSION
+            value: column-reference[a]
+          - element_type: VALUE_EXPRESSION
+            value: column-reference[b]
+        right:
+          - element_type: VALUE_EXPRESSION
+            value: column-reference[b]
+          - element_type: VALUE_EXPRESSION
+            value: column-reference[a]
 # Single-value row value constructor lists are OK too
 >SELECT * FROM t1 WHERE (a) = (b)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: (column-reference[a])
-      right:
-        element_type: VALUE_EXPRESSION
-        value: (column-reference[b])
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: (column-reference[a])
+        right:
+          element_type: VALUE_EXPRESSION
+          value: (column-reference[b])
 # scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: scalar-subquery[
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
 # scalar subquery inside another scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2 WHERE b = (SELECT c FROM t3))
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[a]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: scalar-subquery[
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[a]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2 where[column-reference[b] = scalar-subquery[
 query[selected-columns[column-reference[c]] table-expression[referenced-tables[t3]]]]]]]
 # scalar subquery with correlation and alias
 >SELECT * FROM t1 WHERE num_t2 = (SELECT COUNT(*) FROM t2 WHERE t2.t1_id = t1.id)
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
-  where:
-    - predicate_type: COMPARISON
-      op: EQUAL
-      left:
-        element_type: VALUE_EXPRESSION
-        value: column-reference[num_t2]
-      right:
-        element_type: VALUE_EXPRESSION
-        value: scalar-subquery[
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
+    where:
+      - predicate_type: COMPARISON
+        op: EQUAL
+        left:
+          element_type: VALUE_EXPRESSION
+          value: column-reference[num_t2]
+        right:
+          element_type: VALUE_EXPRESSION
+          value: scalar-subquery[
 query[selected-columns[COUNT(*)] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]]

--- a/tests/grammar/ansi-92/row-value-constructors.test
+++ b/tests/grammar/ansi-92/row-value-constructors.test
@@ -8,18 +8,22 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          - element_type: VALUE_EXPRESSION
-            value: column-reference[a]
-          - element_type: VALUE_EXPRESSION
-            value: column-reference[b]
-        right:
-          - element_type: VALUE_EXPRESSION
-            value: column-reference[b]
-          - element_type: VALUE_EXPRESSION
-            value: column-reference[a]
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  - element_type: VALUE_EXPRESSION
+                    value: column-reference[a]
+                  - element_type: VALUE_EXPRESSION
+                    value: column-reference[b]
+                right:
+                  - element_type: VALUE_EXPRESSION
+                    value: column-reference[b]
+                  - element_type: VALUE_EXPRESSION
+                    value: column-reference[a]
 # Single-value row value constructor lists are OK too
 >SELECT * FROM t1 WHERE (a) = (b)
 statements:
@@ -29,14 +33,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: (column-reference[a])
-        right:
-          element_type: VALUE_EXPRESSION
-          value: (column-reference[b])
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: (column-reference[a])
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: (column-reference[b])
 # scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2)
 statements:
@@ -46,14 +54,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: scalar-subquery[
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
 # scalar subquery inside another scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2 WHERE b = (SELECT c FROM t3))
@@ -64,14 +76,18 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[a]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: scalar-subquery[
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[a]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2 where[column-reference[b] = scalar-subquery[
 query[selected-columns[column-reference[c]] table-expression[referenced-tables[t3]]]]]]]
 # scalar subquery with correlation and alias
@@ -83,12 +99,16 @@ statements:
     referenced_tables:
       - t1
     where:
-      - predicate_type: COMPARISON
-        op: EQUAL
-        left:
-          element_type: VALUE_EXPRESSION
-          value: column-reference[num_t2]
-        right:
-          element_type: VALUE_EXPRESSION
-          value: scalar-subquery[
+      search_condition:
+        terms:
+          - factor:
+              predicate:
+                type: COMPARISON
+                op: EQUAL
+                left:
+                  element_type: VALUE_EXPRESSION
+                  value: column-reference[num_t2]
+                right:
+                  element_type: VALUE_EXPRESSION
+                  value: scalar-subquery[
 query[selected-columns[COUNT(*)] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]]

--- a/tests/grammar/ansi-92/string-expressions.test
+++ b/tests/grammar/ansi-92/string-expressions.test
@@ -1,132 +1,132 @@
 # character string literal value expression primary
 >SELECT 'a' FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - literal['a']
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - literal['a']
+    referenced_tables:
+      - t1
 # national character string literal value expression primary
 >SELECT N'motorček' FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - literal['motorček']
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - literal['motorček']
+    referenced_tables:
+      - t1
 # bit string literal value expression primary
 >SELECT B'01000101101' FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - literal['01000101101']
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - literal['01000101101']
+    referenced_tables:
+      - t1
 # hex string literal value expression primary
 >SELECT X'FE1CD34A' FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - literal['FE1CD34A']
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - literal['FE1CD34A']
+    referenced_tables:
+      - t1
 # A simple scalar subquery
 >SELECT (SELECT b FROM t2) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - scalar-subquery[
+  - type: SELECT
+    selected_columns:
+      - scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
-  referenced_tables:
-    - t1
+    referenced_tables:
+      - t1
 # named and dynamic parameters
 >SELECT :name, :name_long, ? FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - parameter[name]
-    - parameter[name_long]
-    - parameter[?]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - parameter[name]
+      - parameter[name_long]
+      - parameter[?]
+    referenced_tables:
+      - t1
 # character value expression using collation
 >SELECT 'ß' COLLATE utf8mb4_general_ci FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - literal['ß'] COLLATE utf8mb4_general_ci
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - literal['ß'] COLLATE utf8mb4_general_ci
+    referenced_tables:
+      - t1
 # character value expression using concatenation
 >SELECT a || b FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - concatenate[column-reference[a], column-reference[b]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - concatenate[column-reference[a], column-reference[b]]
+    referenced_tables:
+      - t1
 # character value expression using concatenation with some factors having a collation
 >SELECT a || b COLLATE utf8_bin FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - concatenate[column-reference[a], column-reference[b] COLLATE utf8_bin]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - concatenate[column-reference[a], column-reference[b] COLLATE utf8_bin]
+    referenced_tables:
+      - t1
 # SUBSTRING string function with no for length modifier
 >SELECT SUBSTRING(a FROM 1) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - substring[column-reference[a] FROM literal[1]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - substring[column-reference[a] FROM literal[1]]
+    referenced_tables:
+      - t1
 # SUBSTRING string function with a for length modifier
 >SELECT SUBSTRING(a FROM 1 FOR 2) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - substring[column-reference[a] FROM literal[1] FOR literal[2]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - substring[column-reference[a] FROM literal[1] FOR literal[2]]
+    referenced_tables:
+      - t1
 # UPPER and LOWER string functions
 >SELECT UPPER(a), LOWER(a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - upper[column-reference[a]]
-    - lower[column-reference[a]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - upper[column-reference[a]]
+      - lower[column-reference[a]]
+    referenced_tables:
+      - t1
 # TRANSLATE string function
 >SELECT TRANSLATE(a USING utf8_bin) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - translate[column-reference[a] USING utf8_bin]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - translate[column-reference[a] USING utf8_bin]
+    referenced_tables:
+      - t1
 # CONVERT string function
 >SELECT CONVERT(a USING utf8_bin) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - convert[column-reference[a] USING utf8_bin]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - convert[column-reference[a] USING utf8_bin]
+    referenced_tables:
+      - t1
 # TRIM string function with no trim specification or character
 >SELECT TRIM(a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - trim[column-reference[a]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - trim[column-reference[a]]
+    referenced_tables:
+      - t1
 # TRIM string function with trim specifications
 >SELECT TRIM(LEADING ' ' FROM a) FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - trim[LEADING literal[' '] FROM column-reference[a]]
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - trim[LEADING literal[' '] FROM column-reference[a]]
+    referenced_tables:
+      - t1

--- a/tests/grammar/ansi-92/table-references.test
+++ b/tests/grammar/ansi-92/table-references.test
@@ -1,32 +1,32 @@
 # Normal table with no alias
 >SELECT * FROM t1
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1
 # Normal table with an alias using AS keyword
 >SELECT * FROM t1 AS t1_alias
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1 AS t1_alias
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1 AS t1_alias
 # Normal table with an alias NOT using AS keyword
 >SELECT * FROM t1 t1_alias
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - t1 AS t1_alias
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - t1 AS t1_alias
 # Derived table with name using AS keyword
 >SELECT * FROM (SELECT a, b FROM t1) AS t
 statements:
-- type: SELECT
-  selected_columns:
-    - *
-  referenced_tables:
-    - <derived table> AS t
+  - type: SELECT
+    selected_columns:
+      - *
+    referenced_tables:
+      - <derived table> AS t

--- a/tests/grammar/ansi-92/update.test
+++ b/tests/grammar/ansi-92/update.test
@@ -1,15 +1,15 @@
 # UPDATE with no WHERE condition
 >UPDATE t1 SET a = 1
 statements:
-- type: UPDATE
-  table_name: t1
-  set_columns:
-    a: literal[1]
+  - type: UPDATE
+    table_name: t1
+    set_columns:
+      a: literal[1]
 # UPDATE with simple WHERE condition with equality comparison
 >UPDATE t1 SET a = 1 WHERE b = 2
 statements:
-- type: UPDATE
-  table_name: t1
-  set_columns:
-    a: literal[1]
-  where: column-reference[b] = literal[2]
+  - type: UPDATE
+    table_name: t1
+    set_columns:
+      a: literal[1]
+    where: column-reference[b] = literal[2]


### PR DESCRIPTION
Corrects the list item handling in the YAML printer and properly breaks out various structs into their respective attributes and list item handlers.

Issue #104