### PR TITLE
YAML printer breakouts and corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Running ansi-92/create-table ... OK
 Running ansi-92/create-view ... OK
 Running ansi-92/datetime-expressions ... OK
 Running ansi-92/delete ... OK
+Running ansi-92/drop-schema ... OK
 Running ansi-92/drop-view ... OK
 Running ansi-92/grant ... OK
 Running ansi-92/identifiers ... OK

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Running ansi-92/create-view ... OK
 Running ansi-92/datetime-expressions ... OK
 Running ansi-92/delete ... OK
 Running ansi-92/drop-schema ... OK
+Running ansi-92/drop-table ... OK
 Running ansi-92/drop-view ... OK
 Running ansi-92/grant ... OK
 Running ansi-92/identifiers ... OK

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ jaypipes@uberbox:~/src/github.com/jaypipes/sqltoast/tests/grammar$ python runner
 Running ansi-92/alter-table ... OK
 Running ansi-92/case-expressions ... OK
 Running ansi-92/column-definitions ... OK
+Running ansi-92/create-schema ... OK
+Running ansi-92/create-table ... OK
+Running ansi-92/create-view ... OK
 Running ansi-92/datetime-expressions ... OK
 Running ansi-92/delete ... OK
 Running ansi-92/drop-view ... OK

--- a/libsqltoast/include/sqltoast/value.h
+++ b/libsqltoast/include/sqltoast/value.h
@@ -436,12 +436,12 @@ typedef struct character_primary {
 
 // A character factor is a character primary with an optional collation.
 typedef struct character_factor {
-    std::unique_ptr<character_primary_t> value;
+    std::unique_ptr<character_primary_t> primary;
     lexeme_t collation;
     character_factor(
-            std::unique_ptr<character_primary_t>& value,
+            std::unique_ptr<character_primary_t>& primary,
             lexeme_t collation) :
-        value(std::move(value)),
+        primary(std::move(primary)),
         collation(collation)
     {}
 } character_factor_t;

--- a/libsqltoast/src/parser/statements/create_schema.cc
+++ b/libsqltoast/src/parser/statements/create_schema.cc
@@ -108,11 +108,13 @@ default_charset_or_statement_ending:
     // We get here after successfully parsing the <schema name clause>,
     // which must be followed by either a statement ending or a <default
     // character set clause>
+    cur_sym = cur_tok.symbol;
     switch (cur_sym) {
         case SYMBOL_SEMICOLON:
         case SYMBOL_EOS:
             goto push_statement;
         case SYMBOL_DEFAULT:
+            cur_tok = lex.next();
             goto default_charset_clause;
         default:
             goto statement_ending;
@@ -130,6 +132,7 @@ authz_or_statement_ending:
             cur_tok = lex.next();
             goto authorization_clause;
         case SYMBOL_DEFAULT:
+            cur_tok = lex.next();
             goto default_charset_clause;
         default:
             expect_any_error(ctx,

--- a/libsqltoast/src/print/value.cc
+++ b/libsqltoast/src/print/value.cc
@@ -401,7 +401,7 @@ std::ostream& operator<< (std::ostream& out, const character_primary_t& cp) {
 }
 
 std::ostream& operator<< (std::ostream& out, const character_factor_t& cf) {
-    out << *cf.value;
+    out << *cf.primary;
     if (cf.collation)
         out << " COLLATE " << cf.collation;
     return out;

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -207,11 +207,14 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_table_sta
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_table_statement_t& stmt) {
+    ptr.indent(out) << "drop_table_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "table_name: " << stmt.table_name;
     if (stmt.drop_behaviour == sqltoast::DROP_BEHAVIOUR_CASCADE)
        ptr.indent(out) << "drop_behaviour: CASCADE";
     else
        ptr.indent(out) << "drop_behaviour: RESTRICT";
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::add_column_action_t& action) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -1207,16 +1207,23 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_value_
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_factor_t& factor) {
     bool is_list = ptr.in_list(out);
     if (is_list) {
-        ptr.indent(out) << "- value: " << *factor.value;
+        ptr.indent(out) << "- primary: " << *factor.primary;
         ptr.end_list(out);
         ptr.indent_push(out);
     } else {
-        ptr.indent(out) << "value:";
+        ptr.indent(out) << "primary:";
     }
     if (factor.collation)
         ptr.indent(out) << "collation: " << factor.collation;
     if (is_list)
         ptr.indent_pop(out);
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_primary_t& cp) {
+    if (cp.value)
+        out << *cp.value;
+    else
+        out << *cp.string_function;
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_value_expression_t& de) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -488,6 +488,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::select_statement
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_statement_t& stmt) {
+    ptr.indent(out) << "insert_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "table_name: " << stmt.table_name;
     if (stmt.use_default_columns())
         ptr.indent(out) << "default_columns: true";
@@ -509,6 +511,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_statement
         }
         ptr.indent_pop(out);
     }
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_select_statement_t& stmt) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -467,11 +467,14 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::joined_table_t& 
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_view_statement_t& stmt) {
+    ptr.indent(out) << "drop_view_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "view_name: " << stmt.table_name;
     if (stmt.drop_behaviour == sqltoast::DROP_BEHAVIOUR_CASCADE)
        ptr.indent(out) << "drop_behaviour: CASCADE";
     else
        ptr.indent(out) << "drop_behaviour: RESTRICT";
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::select_statement_t& stmt) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -478,9 +478,12 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_view_statem
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::select_statement_t& stmt) {
+    ptr.indent(out) << "select_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "query:";
     ptr.indent_push(out);
     to_yaml(ptr, out, *stmt.query);
+    ptr.indent_pop(out);
     ptr.indent_pop(out);
 }
 

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -535,14 +535,16 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_select_st
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::delete_statement_t& stmt) {
+    ptr.indent(out) << "delete_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "table_name: " << stmt.table_name;
-
     if (stmt.where_condition) {
         ptr.indent(out) << "where:";
         ptr.indent_push(out);
         to_yaml(ptr, out, *stmt.where_condition);
         ptr.indent_pop(out);
     }
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::update_statement_t& stmt) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -609,6 +609,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_action_t& 
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_statement_t& stmt) {
+    ptr.indent(out) << "grant_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "on: ";
     switch (stmt.object_type) {
         case sqltoast::GRANT_OBJECT_TYPE_TABLE:
@@ -645,6 +647,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_statement_
             ptr.indent(out) << "- " << *action;
         ptr.indent_pop(out);
     }
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::search_condition_t& sc) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -137,6 +137,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_schema_statement_t& stmt) {
+    ptr.indent(out) << "create_schema_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "schema_name: " << stmt.schema_name;
     if (stmt.authorization_identifier) {
        ptr.indent(out) << "authorization_identifier: " << stmt.authorization_identifier;
@@ -144,6 +146,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_schema_st
     if (stmt.default_charset) {
        ptr.indent(out) << "default_charset: " << stmt.default_charset;
     }
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_schema_statement_t& stmt) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -515,6 +515,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_statement
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_select_statement_t& stmt) {
+    ptr.indent(out) << "insert_select_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "table_name: " << stmt.table_name;
     if (stmt.use_default_columns())
         ptr.indent(out) << "default_columns: true";
@@ -528,6 +530,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_select_st
     ptr.indent(out) << "query:";
     ptr.indent_push(out);
     to_yaml(ptr, out, *stmt.query);
+    ptr.indent_pop(out);
     ptr.indent_pop(out);
 }
 

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -1124,11 +1124,71 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_primary_
             {
                 const sqltoast::numeric_function_t& sub =
                     static_cast<const sqltoast::numeric_function_t&>(primary);
-                ptr.indent(out) << "function: " << sub;
+                to_yaml(ptr, out, sub);
             }
             break;
     }
     ptr.indent_pop(out);
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_function_t& func) {
+    bool found_length_func = false;
+    ptr.indent(out) << "function:";
+    ptr.indent_push(out);
+    ptr.indent(out) << "type: ";
+    switch (func.type) {
+        case sqltoast::NUMERIC_FUNCTION_TYPE_POSITION:
+            out << "POSITION";
+            {
+                const sqltoast::position_expression_t& sub =
+                    static_cast<const sqltoast::position_expression_t&>(func);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case sqltoast::NUMERIC_FUNCTION_TYPE_EXTRACT:
+            out << "EXTRACT";
+            {
+                const sqltoast::extract_expression_t& sub =
+                    static_cast<const sqltoast::extract_expression_t&>(func);
+                to_yaml(ptr, out, sub);
+            }
+            break;
+        case sqltoast::NUMERIC_FUNCTION_TYPE_CHAR_LENGTH:
+            out << "CHAR_LENGTH";
+            found_length_func = true;
+            break;
+        case sqltoast::NUMERIC_FUNCTION_TYPE_BIT_LENGTH:
+            out << "BIT_LENGTH";
+            found_length_func = true;
+            break;
+        case sqltoast::NUMERIC_FUNCTION_TYPE_OCTET_LENGTH:
+            out << "OCTET_LENGTH";
+            found_length_func = true;
+            break;
+        default:
+            // TODO(jaypipes)
+            break;
+    }
+    if (found_length_func) {
+        const sqltoast::length_expression_t& sub =
+            static_cast<const sqltoast::length_expression_t&>(func);
+        to_yaml(ptr, out, sub);
+    }
+    ptr.indent_pop(out);
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::length_expression_t& expr) {
+    ptr.indent(out) << "operand: " << *expr.operand;
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::position_expression_t& expr) {
+    ptr.indent(out) << "find: " << *expr.to_find;
+    ptr.indent(out) << "in: " << *expr.subject;
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::extract_expression_t& expr) {
+    ptr.indent(out) << "field: " << expr.extract_field;
+    ptr.indent(out) << "source: " << *expr.extract_source;
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_value_expression_t& cve) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -548,6 +548,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::delete_statement
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::update_statement_t& stmt) {
+    ptr.indent(out) << "update_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "table_name: " << stmt.table_name;
     ptr.indent(out) << "set_columns:";
     ptr.indent_push(out);
@@ -568,6 +570,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::update_statement
         to_yaml(ptr, out, *stmt.where_condition);
         ptr.indent_pop(out);
     }
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_action_t& action) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -299,6 +299,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::alter_table_stat
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_view_statement_t& stmt) {
+    ptr.indent(out) << "create_view_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "view_name: " << stmt.table_name;
     if (! stmt.columns.empty()) {
         ptr.indent(out) << "columns:";
@@ -316,6 +318,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_view_stat
     ptr.indent(out) << "query:";
     ptr.indent_push(out);
     to_yaml(ptr, out, *stmt.query);
+    ptr.indent_pop(out);
     ptr.indent_pop(out);
 }
 

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -161,6 +161,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_schema_stat
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_table_statement_t& stmt) {
+    ptr.indent(out) << "create_table_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "table_name: " << stmt.table_name;
     if (stmt.table_type != sqltoast::TABLE_TYPE_NORMAL) {
         ptr.indent(out) << "temporary: true (";
@@ -201,6 +203,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_table_sta
         }
         ptr.indent_pop(out);
     }
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_table_statement_t& stmt) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -291,8 +291,11 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::alter_table_acti
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::alter_table_statement_t& stmt) {
+    ptr.indent(out) << "alter_table_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "table_name: " << stmt.table_name;
     ptr.indent(out) << "action: " << *stmt.action;
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_view_statement_t& stmt) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -150,11 +150,14 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_schema_st
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_schema_statement_t& stmt) {
+    ptr.indent(out) << "drop_schema_statement:";
+    ptr.indent_push(out);
     ptr.indent(out) << "schema_name: " << stmt.schema_name;
     if (stmt.drop_behaviour == sqltoast::DROP_BEHAVIOUR_CASCADE)
        ptr.indent(out) << "drop_behaviour: CASCADE";
     else
        ptr.indent(out) << "drop_behaviour: RESTRICT";
+    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_table_statement_t& stmt) {

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -24,6 +24,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_factor_t
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_primary_t& bp);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::boolean_term_t& bt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_factor_t& factor);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_primary_t& cp);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_value_expression_t& cve);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::comp_op_t& op);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::comp_predicate_t& pred);

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -41,6 +41,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_schema_stat
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_table_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::drop_view_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::exists_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::extract_expression_t& expr);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_action_t& action);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_subquery_predicate_t& pred);
@@ -52,6 +53,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_term_t&
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_value_expression_t& ie);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::joined_table_query_expression_t& qe);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::joined_table_t& jt);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::length_expression_t& expr);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::like_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::match_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::non_join_query_expression_t& qe);
@@ -60,9 +62,11 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::non_join_query_t
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::null_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_expression_t& expr);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_factor_t& factor);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_primary_t& primary);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_term_t& term);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::overlaps_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::position_expression_t& expr);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::quantified_comparison_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::query_expression_t& qe);

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -28,6 +28,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_primar
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::character_value_expression_t& cve);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::comp_op_t& op);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::comp_predicate_t& pred);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::convert_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_schema_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_table_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_view_statement_t& stmt);
@@ -79,7 +80,11 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::row_value_expres
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::search_condition_t& sc);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::select_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stmt);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::string_function_t& func);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::substring_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_expression_t& table_exp);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::translate_function_t& func);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::trim_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::unique_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::update_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::value_expression_t& ve);

--- a/tests/grammar/ansi-92/alter-table.test
+++ b/tests/grammar/ansi-92/alter-table.test
@@ -14,107 +14,125 @@ ALTER TABLE t1 ADD COLUMN b;
 >ALTER TABLE t1 ADD COLUMN b INT;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ADD COLUMN b INT
+    alter_table_statement:
+      table_name: t1
+      action: ADD COLUMN b INT
 # ADD COLUMN action without optional COLUMN keyword
 >ALTER TABLE t1 ADD b INT;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ADD COLUMN b INT
+    alter_table_statement:
+      table_name: t1
+      action: ADD COLUMN b INT
 # ALTER COLUMN SET DEFAULT action
 >ALTER TABLE t1 ALTER COLUMN b SET DEFAULT NULL;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ALTER COLUMN b SET DEFAULT NULL
+    alter_table_statement:
+      table_name: t1
+      action: ALTER COLUMN b SET DEFAULT NULL
 # ALTER COLUMN SET DEFAULT action optional COLUMN keyword
 >ALTER TABLE t1 ALTER b SET DEFAULT NULL;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ALTER COLUMN b SET DEFAULT NULL
+    alter_table_statement:
+      table_name: t1
+      action: ALTER COLUMN b SET DEFAULT NULL
 # ALTER COLUMN DROP DEFAULT action
 >ALTER TABLE t1 ALTER COLUMN b DROP DEFAULT;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ALTER COLUMN b DROP DEFAULT
+    alter_table_statement:
+      table_name: t1
+      action: ALTER COLUMN b DROP DEFAULT
 # DROP COLUMN action no drop behaviour
 >ALTER TABLE t1 DROP COLUMN b;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: DROP COLUMN b CASCADE
+    alter_table_statement:
+      table_name: t1
+      action: DROP COLUMN b CASCADE
 # DROP COLUMN action no drop behaviour no optional COLUMN keyword
 >ALTER TABLE t1 DROP b;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: DROP COLUMN b CASCADE
+    alter_table_statement:
+      table_name: t1
+      action: DROP COLUMN b CASCADE
 # DROP COLUMN action with explicit drop behaviour of default CASCADE
 >ALTER TABLE t1 DROP COLUMN b CASCADE;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: DROP COLUMN b CASCADE
+    alter_table_statement:
+      table_name: t1
+      action: DROP COLUMN b CASCADE
 # DROP COLUMN action with explicit drop behaviour of RESTRICT
 >ALTER TABLE t1 DROP COLUMN b RESTRICT;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: DROP COLUMN b RESTRICT
+    alter_table_statement:
+      table_name: t1
+      action: DROP COLUMN b RESTRICT
 # ADD CONSTRAINT action with UNIQUE constraint
 >ALTER TABLE t1 ADD UNIQUE (b, c);
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ADD UNIQUE (b,c)
+    alter_table_statement:
+      table_name: t1
+      action: ADD UNIQUE (b,c)
 # ADD CONSTRAINT action with UNIQUE constraint with constraint name
 >ALTER TABLE t1 ADD CONSTRAINT u_bc UNIQUE (b, c);
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ADD CONSTRAINT u_bc UNIQUE (b,c)
+    alter_table_statement:
+      table_name: t1
+      action: ADD CONSTRAINT u_bc UNIQUE (b,c)
 # ADD CONSTRAINT action with PRIMARY KEY constraint
 >ALTER TABLE t1 ADD PRIMARY KEY (b, c);
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ADD PRIMARY KEY (b,c)
+    alter_table_statement:
+      table_name: t1
+      action: ADD PRIMARY KEY (b,c)
 # ADD CONSTRAINT action with PRIMARY KEY constraint with constraint name
 >ALTER TABLE t1 ADD CONSTRAINT pk PRIMARY KEY (b, c);
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ADD CONSTRAINT pk PRIMARY KEY (b,c)
+    alter_table_statement:
+      table_name: t1
+      action: ADD CONSTRAINT pk PRIMARY KEY (b,c)
 # ADD CONSTRAINT action with FOREIGN KEY constraint
 >ALTER TABLE t1 ADD FOREIGN KEY (t2_id) REFERENCES t2 (id);
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ADD FOREIGN KEY (t2_id) REFERENCES t2 (id)
+    alter_table_statement:
+      table_name: t1
+      action: ADD FOREIGN KEY (t2_id) REFERENCES t2 (id)
 # ADD CONSTRAINT action with FOREIGN KEY constraint with constraint name
 >ALTER TABLE t1 ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id);
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id)
+    alter_table_statement:
+      table_name: t1
+      action: ADD CONSTRAINT fk_t2 FOREIGN KEY (t2_id) REFERENCES t2 (id)
 # DROP CONSTRAINT action no drop behaviour
 >ALTER TABLE t1 DROP CONSTRAINT b;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: DROP CONSTRAINT b CASCADE
+    alter_table_statement:
+      table_name: t1
+      action: DROP CONSTRAINT b CASCADE
 # DROP CONSTRAINT action with explicit drop behaviour of default CASCADE
 >ALTER TABLE t1 DROP CONSTRAINT b CASCADE;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: DROP CONSTRAINT b CASCADE
+    alter_table_statement:
+      table_name: t1
+      action: DROP CONSTRAINT b CASCADE
 # DROP CONSTRAINT action with explicit drop behaviour of RESTRICT
 >ALTER TABLE t1 DROP CONSTRAINT b RESTRICT;
 statements:
   - type: ALTER_TABLE
-    table_name: t1
-    action: DROP CONSTRAINT b RESTRICT
+    alter_table_statement:
+      table_name: t1
+      action: DROP CONSTRAINT b RESTRICT

--- a/tests/grammar/ansi-92/case-expressions.test
+++ b/tests/grammar/ansi-92/case-expressions.test
@@ -14,197 +14,208 @@ SELECT COALESCE()
 >SELECT COALESCE(a, 'n/a') FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: coalesce[column-reference[a],literal['n/a']]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: coalesce[column-reference[a],literal['n/a']]
+        referenced_tables:
+          - t1
 # COALESCE with 4 args
 >SELECT COALESCE(a, b, c, 'n/a') FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: coalesce[column-reference[a],column-reference[b],column-reference[c],literal['n/a']]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: coalesce[column-reference[a],column-reference[b],column-reference[c],literal['n/a']]
+        referenced_tables:
+          - t1
 # NULLIF with 2 args
 >SELECT NULLIF(a, 'n/a') FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: nullif[column-reference[a],literal['n/a']]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: nullif[column-reference[a],literal['n/a']]
+        referenced_tables:
+          - t1
 # Simple CASE expression single WHEN no ELSE
 >SELECT CASE a WHEN 1 THEN 2 END FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2]]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2]]
+        referenced_tables:
+          - t1
 # Simple CASE expression multiple WHEN no ELSE
 >SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 END FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3]]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3]]
+        referenced_tables:
+          - t1
 # Simple CASE expression single WHEN with ELSE
 >SELECT CASE a WHEN 1 THEN 2 ELSE 42 END FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] ELSE literal[42]]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] ELSE literal[42]]
+        referenced_tables:
+          - t1
 # Simple CASE expression multiple WHEN with ELSE
 >SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3] ELSE literal[4]]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3] ELSE literal[4]]
+        referenced_tables:
+          - t1
 # Searched CASE expression single WHEN no ELSE
 >SELECT CASE WHEN a = 1 THEN 2 END FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2]]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2]]
+        referenced_tables:
+          - t1
 # Searched CASE expression multiple WHEN no ELSE
 >SELECT CASE WHEN a = 1 THEN 2 WHEN a = 2 THEN 3 END FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3]]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3]]
+        referenced_tables:
+          - t1
 # Searched CASE expression single WHEN with ELSE
 >SELECT CASE WHEN a = 1 THEN 2 ELSE 42 END FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] ELSE literal[42]]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] ELSE literal[42]]
+        referenced_tables:
+          - t1
 # Searched CASE expression multiple WHEN with ELSE
 >SELECT CASE WHEN a = 1 THEN 2 WHEN a = 2 THEN 3 ELSE 4 END FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3] ELSE literal[4]]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3] ELSE literal[4]]
+        referenced_tables:
+          - t1

--- a/tests/grammar/ansi-92/column-definitions.test
+++ b/tests/grammar/ansi-92/column-definitions.test
@@ -12,17 +12,18 @@
 >)
 statements:
   - type: CREATE_TABLE
-    table_name: t1
-    column_definitions:
-      a: INT
-      b: INT
-      c: SMALLINT
-      d: NUMERIC
-      e: NUMERIC
-      f: NUMERIC
-      g: FLOAT
-      h: FLOAT(24)
-      i: DOUBLE PRECISION
+    create_table_statement:
+      table_name: t1
+      column_definitions:
+        a: INT
+        b: INT
+        c: SMALLINT
+        d: NUMERIC
+        e: NUMERIC
+        f: NUMERIC
+        g: FLOAT
+        h: FLOAT(24)
+        i: DOUBLE PRECISION
 # Character column definitions
 >CREATE TABLE t1 (
 >    a CHAR,
@@ -38,18 +39,19 @@ statements:
 >)
 statements:
   - type: CREATE_TABLE
-    table_name: t1
-    column_definitions:
-      a: CHAR
-      b: CHAR
-      c: CHAR(10)
-      d: CHAR(10)
-      e: VARCHAR
-      f: VARCHAR
-      g: VARCHAR
-      h: VARCHAR(10)
-      i: VARCHAR(10)
-      j: VARCHAR(10)
+    create_table_statement:
+      table_name: t1
+      column_definitions:
+        a: CHAR
+        b: CHAR
+        c: CHAR(10)
+        d: CHAR(10)
+        e: VARCHAR
+        f: VARCHAR
+        g: VARCHAR
+        h: VARCHAR(10)
+        i: VARCHAR(10)
+        j: VARCHAR(10)
 # default descriptors of various kinds
 >CREATE TABLE t1 (
 >    a INT DEFAULT 0,
@@ -59,9 +61,10 @@ statements:
 >)
 statements:
   - type: CREATE_TABLE
-    table_name: t1
-    column_definitions:
-      a: INT DEFAULT 0
-      b: INT DEFAULT -1
-      c: VARCHAR DEFAULT CURRENT_USER
-      d: DATE DEFAULT CURRENT_DATE
+    create_table_statement:
+      table_name: t1
+      column_definitions:
+        a: INT DEFAULT 0
+        b: INT DEFAULT -1
+        c: VARCHAR DEFAULT CURRENT_USER
+        d: DATE DEFAULT CURRENT_DATE

--- a/tests/grammar/ansi-92/create-schema.test
+++ b/tests/grammar/ansi-92/create-schema.test
@@ -1,0 +1,34 @@
+# Missing schema name
+>CREATE SCHEMA
+Syntax error.
+Expected to find << identifier >> but found symbol[EOS]
+CREATE SCHEMA
+            ^
+# Simple CREATE SCHEMA no options
+>CREATE SCHEMA s1
+statements:
+  - type: CREATE_SCHEMA
+    create_schema_statement:
+      schema_name: s1
+# Simple CREATE SCHEMA with authorizer
+>CREATE SCHEMA s1 AUTHORIZATION usr
+statements:
+  - type: CREATE_SCHEMA
+    create_schema_statement:
+      schema_name: s1
+      authorization_identifier: usr
+# Simple CREATE SCHEMA with default character set
+>CREATE SCHEMA s1 DEFAULT CHARACTER SET utf8
+statements:
+  - type: CREATE_SCHEMA
+    create_schema_statement:
+      schema_name: s1
+      default_charset: utf8
+# Simple CREATE SCHEMA with default character set and authorization
+>CREATE SCHEMA s1 AUTHORIZATION usr DEFAULT CHARACTER SET utf8
+statements:
+  - type: CREATE_SCHEMA
+    create_schema_statement:
+      schema_name: s1
+      authorization_identifier: usr
+      default_charset: utf8

--- a/tests/grammar/ansi-92/create-table.test
+++ b/tests/grammar/ansi-92/create-table.test
@@ -4,42 +4,47 @@
 >)
 statements:
   - type: CREATE_TABLE
-    table_name: t1
-    column_definitions:
-      a: INT NOT NULL
+    create_table_statement:
+      table_name: t1
+      column_definitions:
+        a: INT NOT NULL
 # PRIMARY KEY
 >CREATE TABLE t1 (
 >    a INT PRIMARY KEY
 >)
 statements:
   - type: CREATE_TABLE
-    table_name: t1
-    column_definitions:
-      a: INT PRIMARY KEY
+    create_table_statement:
+      table_name: t1
+      column_definitions:
+        a: INT PRIMARY KEY
 # NOT NULL constraint plus PRIMARY KEY
 >CREATE TABLE t1 (
 >    a INT NOT NULL PRIMARY KEY
 >)
 statements:
   - type: CREATE_TABLE
-    table_name: t1
-    column_definitions:
-      a: INT NOT NULL PRIMARY KEY
+    create_table_statement:
+      table_name: t1
+      column_definitions:
+        a: INT NOT NULL PRIMARY KEY
 # UNIQUE constraint on single column
 >CREATE TABLE t1 (
 >    a CHAR UNIQUE
 >)
 statements:
   - type: CREATE_TABLE
-    table_name: t1
-    column_definitions:
-      a: CHAR UNIQUE
+    create_table_statement:
+      table_name: t1
+      column_definitions:
+        a: CHAR UNIQUE
 # NOT NULL constraint plus UNIQUE
 >CREATE TABLE t1 (
 >    a CHAR(10) NOT NULL UNIQUE
 >)
 statements:
   - type: CREATE_TABLE
-    table_name: t1
-    column_definitions:
-      a: CHAR(10) NOT NULL UNIQUE
+    create_table_statement:
+      table_name: t1
+      column_definitions:
+        a: CHAR(10) NOT NULL UNIQUE

--- a/tests/grammar/ansi-92/create-view.test
+++ b/tests/grammar/ansi-92/create-view.test
@@ -13,69 +13,73 @@ CREATE VIEW v1 SELECT * FROM t1
 >CREATE VIEW v1 AS SELECT * FROM t1
 statements:
   - type: CREATE_VIEW
-    view_name: v1
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
+    create_view_statement:
+      view_name: v1
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
 # Use the optional column list
 >CREATE VIEW v1 (a, b) AS SELECT a, b FROM t1
 statements:
   - type: CREATE_VIEW
-    view_name: v1
-    columns:
-      - a
-      - b
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: column-reference[a]
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: column-reference[b]
-      referenced_tables:
-        - t1
+    create_view_statement:
+      view_name: v1
+      columns:
+        - a
+        - b
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: column-reference[a]
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: column-reference[b]
+        referenced_tables:
+          - t1
 # The optional WITH LOCAL CHECK OPTION clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH LOCAL CHECK OPTION
 statements:
   - type: CREATE_VIEW
-    view_name: v1
-    check_option: LOCAL
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
+    create_view_statement:
+      view_name: v1
+      check_option: LOCAL
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
 # The optional WITH CASCADED CHECK OPTION clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH CASCADED CHECK OPTION
 statements:
   - type: CREATE_VIEW
-    view_name: v1
-    check_option: CASCADED
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
+    create_view_statement:
+      view_name: v1
+      check_option: CASCADED
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
 # Missing either LOCAL or CASCADED for the check option clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH CHECK OPTION
 Syntax error.

--- a/tests/grammar/ansi-92/datetime-expressions.test
+++ b/tests/grammar/ansi-92/datetime-expressions.test
@@ -2,181 +2,191 @@
 >SELECT a AT LOCAL FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: column-reference[a]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: LOCAL
+                        value: column-reference[a]
+        referenced_tables:
+          - t1
 # Simple datetime expression with specifier timezone
 >SELECT a AT TIME ZONE 'UTC' FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: 'UTC'
-                      value: column-reference[a]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: 'UTC'
+                        value: column-reference[a]
+        referenced_tables:
+          - t1
 # CURRENT_DATE datetime function
 >SELECT CURRENT_DATE FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: current-date[]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: LOCAL
+                        value: current-date[]
+        referenced_tables:
+          - t1
 # CURRENT_DATE datetime function with timezone component
 >SELECT CURRENT_DATE AT TIME ZONE 'UTC' FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: 'UTC'
-                      value: current-date[]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: 'UTC'
+                        value: current-date[]
+        referenced_tables:
+          - t1
 # CURRENT_TIME datetime function with no time precision
 >SELECT CURRENT_TIME FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: current-time[]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: LOCAL
+                        value: current-time[]
+        referenced_tables:
+          - t1
 # CURRENT_TIME datetime function with fractional time precision
 >SELECT CURRENT_TIME(3) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: current-time[3]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: LOCAL
+                        value: current-time[3]
+        referenced_tables:
+          - t1
 # CURRENT_TIMESTAMP datetime function with no time precision
 >SELECT CURRENT_TIMESTAMP FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: current-timestamp[]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: LOCAL
+                        value: current-timestamp[]
+        referenced_tables:
+          - t1
 # CURRENT_TIMESTAMP datetime function with fractional time precision
 >SELECT CURRENT_TIMESTAMP(3) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: current-timestamp[3]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: LOCAL
+                        value: current-timestamp[3]
+        referenced_tables:
+          - t1
 # Add a datetime term to an interval term
 >SELECT a AT LOCAL + b YEAR TO MONTH FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: column-reference[a]
-                op: ADD
-                right:
-                  term:
-                    left:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
                       factor:
-                        primary: column-reference[b] YEAR TO MONTH
-      referenced_tables:
-        - t1
+                        time_zone: LOCAL
+                        value: column-reference[a]
+                  op: ADD
+                  right:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[b] YEAR TO MONTH
+        referenced_tables:
+          - t1
 # Subtract an interval term from a datetime expression
 >SELECT a AT LOCAL - b DAY FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: column-reference[a]
-                op: SUBTRACT
-                right:
-                  term:
-                    left:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
                       factor:
-                        primary: column-reference[b] DAY
-      referenced_tables:
-        - t1
+                        time_zone: LOCAL
+                        value: column-reference[a]
+                  op: SUBTRACT
+                  right:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[b] DAY
+        referenced_tables:
+          - t1

--- a/tests/grammar/ansi-92/delete.test
+++ b/tests/grammar/ansi-92/delete.test
@@ -2,44 +2,46 @@
 >DELETE FROM t1
 statements:
   - type: DELETE
-    table_name: t1
+    delete_statement:
+      table_name: t1
 # DELETE with simple WHERE condition with equality comparison
 >DELETE FROM t1 WHERE a = 10
 statements:
   - type: DELETE
-    table_name: t1
-    where:
-      search_condition:
-        terms:
-          - factor:
-              predicate:
-                type: COMPARISON
-                op: EQUAL
-                left:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: column-reference[a]
-                right:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[10]
+    delete_statement:
+      table_name: t1
+      where:
+        search_condition:
+          terms:
+            - factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: column-reference[a]
+                  right:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: literal[10]

--- a/tests/grammar/ansi-92/drop-schema.test
+++ b/tests/grammar/ansi-92/drop-schema.test
@@ -1,0 +1,33 @@
+# Simple DROP SCHEMA with no drop behaviour defaults to CASCADE
+>DROP SCHEMA s1
+statements:
+  - type: DROP_SCHEMA
+    drop_schema_statement:
+      schema_name: s1
+      drop_behaviour: CASCADE
+# Simple DROP SCHEMA with explicit drop behaviour of CASCADE
+>DROP SCHEMA s1 CASCADE
+statements:
+  - type: DROP_SCHEMA
+    drop_schema_statement:
+      schema_name: s1
+      drop_behaviour: CASCADE
+# Simple DROP SCHEMA with explicit drop behaviour of RESTRICT
+>DROP SCHEMA s1 RESTRICT
+statements:
+  - type: DROP_SCHEMA
+    drop_schema_statement:
+      schema_name: s1
+      drop_behaviour: RESTRICT
+# Syntax error missing table/schema name
+>DROP SCHEMA
+Syntax error.
+Expected to find << identifier >> but found symbol[EOS]
+DROP SCHEMA
+          ^
+# Syntax error expecting statement ending
+>DROP SCHEMA s1 UNKNOWN
+Syntax error.
+Expected to find one of (EOS|';') but found identifier[UNKNOWN]
+DROP SCHEMA s1 UNKNOWN
+              ^^^^^^^^

--- a/tests/grammar/ansi-92/drop-table.test
+++ b/tests/grammar/ansi-92/drop-table.test
@@ -1,0 +1,33 @@
+# Simple DROP TABLE with no drop behaviour defaults to CASCADE
+>DROP TABLE t1
+statements:
+  - type: DROP_TABLE
+    drop_table_statement:
+      table_name: t1
+      drop_behaviour: CASCADE
+# Simple DROP TABLE with explicit drop behaviour of CASCADE
+>DROP TABLE t1 CASCADE
+statements:
+  - type: DROP_TABLE
+    drop_table_statement:
+      table_name: t1
+      drop_behaviour: CASCADE
+# Simple DROP TABLE with explicit drop behaviour of RESTRICT
+>DROP TABLE t1 RESTRICT
+statements:
+  - type: DROP_TABLE
+    drop_table_statement:
+      table_name: t1
+      drop_behaviour: RESTRICT
+# Syntax error missing table/table name
+>DROP TABLE
+Syntax error.
+Expected to find << identifier >> but found symbol[EOS]
+DROP TABLE
+         ^
+# Syntax error expecting statement ending
+>DROP TABLE t1 UNKNOWN
+Syntax error.
+Expected to find one of (EOS|';') but found identifier[UNKNOWN]
+DROP TABLE t1 UNKNOWN
+             ^^^^^^^^

--- a/tests/grammar/ansi-92/drop-view.test
+++ b/tests/grammar/ansi-92/drop-view.test
@@ -2,20 +2,23 @@
 >DROP VIEW v1
 statements:
   - type: DROP_VIEW
-    view_name: v1
-    drop_behaviour: CASCADE
+    drop_view_statement:
+      view_name: v1
+      drop_behaviour: CASCADE
 # Simple DROP VIEW with explicit drop behaviour of CASCADE
 >DROP VIEW v1 CASCADE
 statements:
   - type: DROP_VIEW
-    view_name: v1
-    drop_behaviour: CASCADE
+    drop_view_statement:
+      view_name: v1
+      drop_behaviour: CASCADE
 # Simple DROP VIEW with explicit drop behaviour of RESTRICT
 >DROP VIEW v1 RESTRICT
 statements:
   - type: DROP_VIEW
-    view_name: v1
-    drop_behaviour: RESTRICT
+    drop_view_statement:
+      view_name: v1
+      drop_behaviour: RESTRICT
 # Syntax error missing table/view name
 >DROP VIEW
 Syntax error.

--- a/tests/grammar/ansi-92/grant.test
+++ b/tests/grammar/ansi-92/grant.test
@@ -38,70 +38,78 @@ GRANT ALL PRIVILEGES ON db TO usr WITH GRANT
 >GRANT ALL PRIVILEGES ON db TO usr
 statements:
   - type: GRANT
-    on: db
-    to: usr
-    privileges:
-      - ALL
+    grant_statement:
+      on: db
+      to: usr
+      privileges:
+        - ALL
 # GRANT specific privileges to a user, no grant option
 >GRANT SELECT, DELETE, USAGE ON db TO usr
 statements:
   - type: GRANT
-    on: db
-    to: usr
-    privileges:
-      - SELECT
-      - DELETE
-      - USAGE
+    grant_statement:
+      on: db
+      to: usr
+      privileges:
+        - SELECT
+        - DELETE
+        - USAGE
 # GRANT privilege with action taking columns
 >GRANT INSERT (a, b, c) ON tbl TO usr
 statements:
   - type: GRANT
-    on: tbl
-    to: usr
-    privileges:
-      - INSERT (a,b,c)
+    grant_statement:
+      on: tbl
+      to: usr
+      privileges:
+        - INSERT (a,b,c)
 # GRANT privilege with action taking columns along with no optional columns for
 # update
 >GRANT INSERT (a, b, c), UPDATE ON tbl TO usr
 statements:
   - type: GRANT
-    on: tbl
-    to: usr
-    privileges:
-      - INSERT (a,b,c)
-      - UPDATE
+    grant_statement:
+      on: tbl
+      to: usr
+      privileges:
+        - INSERT (a,b,c)
+        - UPDATE
 # GRANT all on domain object to a user
 >GRANT ALL PRIVILEGES ON DOMAIN dom TO usr
 statements:
   - type: GRANT
-    on: DOMAIN dom
-    to: usr
-    privileges:
-      - ALL
+    grant_statement:
+      on: DOMAIN dom
+      to: usr
+      privileges:
+        - ALL
 # GRANT all on collation object to a user
 >GRANT ALL PRIVILEGES ON COLLATION utf8bin TO usr
 statements:
   - type: GRANT
-    on: COLLATION utf8bin
-    to: usr
-    privileges:
-      - ALL
+    grant_statement:
+      on: COLLATION utf8bin
+      to: usr
+      privileges:
+        - ALL
 # GRANT all on characterset object to a user
 >GRANT ALL PRIVILEGES ON CHARACTER SET utf8 TO usr
 statements:
   - type: GRANT
-    on: CHARACTER SET utf8
-    to: usr
-    privileges:
-      - ALL
+    grant_statement:
+      on: CHARACTER SET utf8
+      to: usr
+      privileges:
+        - ALL
 # GRANT all on translation object to a user
 >GRANT ALL PRIVILEGES ON TRANSLATION trns TO usr
 statements:
   - type: GRANT
-    on: TRANSLATION trns
-    to: usr
-    privileges:
-      - ALL
+    grant_statement:
+      on: TRANSLATION trns
+      to: usr
+      privileges:
+        - ALL
 # Syntax error expecting SET after CHARACTER
 >GRANT ALL PRIVILEGES ON CHARACTER utf8 TO usr
 Syntax error.

--- a/tests/grammar/ansi-92/identifiers.test
+++ b/tests/grammar/ansi-92/identifiers.test
@@ -2,57 +2,62 @@
 >SELECT * FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
 # Identifier includes an underscore
 >SELECT * FROM t1_backup
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1_backup
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1_backup
 # Identifier includes a period
 >SELECT * FROM s1.t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - s1.t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - s1.t1
 # Identifier includes multiple periods and underscore
 >SELECT * FROM c1.s1.t1_backup
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - c1.s1.t1_backup
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - c1.s1.t1_backup
 # Identifier includes a prefix and a star projection
 >SELECT t1.* FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: column-reference[t1.*]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: column-reference[t1.*]
+        referenced_tables:
+          - t1

--- a/tests/grammar/ansi-92/insert-default-values.test
+++ b/tests/grammar/ansi-92/insert-default-values.test
@@ -1,6 +1,7 @@
 >INSERT INTO t1 DEFAULT VALUES
 statements:
   - type: INSERT
-    table_name: t1
-    default_columns: true
-    default_values: true
+    insert_statement:
+      table_name: t1
+      default_columns: true
+      default_values: true

--- a/tests/grammar/ansi-92/insert-select.test
+++ b/tests/grammar/ansi-92/insert-select.test
@@ -2,96 +2,98 @@
 >INSERT INTO t1 SELECT a, b FROM t1
 statements:
   - type: INSERT_SELECT
-    table_name: t1
-    default_columns: true
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: column-reference[a]
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: column-reference[b]
-      referenced_tables:
-        - t1
+    insert_select_statement:
+      table_name: t1
+      default_columns: true
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: column-reference[a]
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: column-reference[b]
+        referenced_tables:
+          - t1
 # INSERT SELECT with target columns and a search condition
 >INSERT INTO t1 (t1_a, t1_b) SELECT a, b FROM t1 WHERE c < 3
 statements:
   - type: INSERT_SELECT
-    table_name: t1
-    columns:
-      - t1_a
-      - t1_b
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: column-reference[a]
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: column-reference[b]
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: LESS_THAN
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[c]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[3]
+    insert_select_statement:
+      table_name: t1
+      columns:
+        - t1_a
+        - t1_b
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: column-reference[a]
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: column-reference[b]
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: LESS_THAN
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[c]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[3]

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -80,7 +80,8 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: literal['a']
+                  - primary:
+                      value: literal['a']
                     collation: utf8bin
 # INSERT INTO using datetime value expressions
 >INSERT INTO t1 (create_date, my_date) VALUES (CURRENT_DATE, '2001-01-01' AT TIME ZONE 'UTC')

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -80,7 +80,7 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: literal['a']
+                  - primary: literal['a']
                     collation: utf8bin
 # INSERT INTO using datetime value expressions
 >INSERT INTO t1 (create_date, my_date) VALUES (CURRENT_DATE, '2001-01-01' AT TIME ZONE 'UTC')

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -1,168 +1,174 @@
 >INSERT INTO t1 (a, b) VALUES (1, 2)
 statements:
   - type: INSERT
-    table_name: t1
-    columns:
-      - a
-      - b
-    values:
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal[1]
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal[2]
-# INSERT INTO with a default columns list
->INSERT INTO t1 VALUES (1, 2)
-statements:
-  - type: INSERT
-    table_name: t1
-    default_columns: true
-    values:
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal[1]
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal[2]
-# INSERT INTO using a character values expression
->INSERT INTO t1 VALUES ('a' COLLATE utf8bin)
-statements:
-  - type: INSERT
-    table_name: t1
-    default_columns: true
-    values:
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      value: literal['a']
-                    collation: utf8bin
-# INSERT INTO using datetime value expressions
->INSERT INTO t1 (create_date, my_date) VALUES (CURRENT_DATE, '2001-01-01' AT TIME ZONE 'UTC')
-statements:
-  - type: INSERT
-    table_name: t1
-    columns:
-      - create_date
-      - my_date
-    values:
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: LOCAL
-                      value: current-date[]
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: DATETIME_EXPRESSION
-              datetime_expression:
-                left:
-                  term:
-                    factor:
-                      time_zone: 'UTC'
-                      value: literal['2001-01-01']
-# INSERT INTO using interval value expressions
->INSERT INTO t1 (num_seconds) VALUES ('2001-01-01' DAY TO SECOND)
-statements:
-  - type: INSERT
-    table_name: t1
-    columns:
-      - num_seconds
-    values:
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: literal['2001-01-01'] DAY TO SECOND
-# INSERT INTO using numeric value expressions
->INSERT INTO t1 (num_seconds) VALUES (1 + (2 * 3))
-statements:
-  - type: INSERT
-    table_name: t1
-    columns:
-      - num_seconds
-    values:
-      - row_value_constructor:
-          type: ELEMENT
-          element:
-            type: VALUE_EXPRESSION
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                left:
+    insert_statement:
+      table_name: t1
+      columns:
+        - a
+        - b
+      values:
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
                   term:
                     left:
                       factor:
                         primary:
                           type: VALUE
                           value: literal[1]
-                op: ADD
-                right:
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
                   term:
                     left:
                       factor:
                         primary:
                           type: VALUE
-                          value: (numeric-expression[literal[2] * literal[3]])
+                          value: literal[2]
+# INSERT INTO with a default columns list
+>INSERT INTO t1 VALUES (1, 2)
+statements:
+  - type: INSERT
+    insert_statement:
+      table_name: t1
+      default_columns: true
+      values:
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: literal[1]
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: literal[2]
+# INSERT INTO using a character values expression
+>INSERT INTO t1 VALUES ('a' COLLATE utf8bin)
+statements:
+  - type: INSERT
+    insert_statement:
+      table_name: t1
+      default_columns: true
+      values:
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        value: literal['a']
+                      collation: utf8bin
+# INSERT INTO using datetime value expressions
+>INSERT INTO t1 (create_date, my_date) VALUES (CURRENT_DATE, '2001-01-01' AT TIME ZONE 'UTC')
+statements:
+  - type: INSERT
+    insert_statement:
+      table_name: t1
+      columns:
+        - create_date
+        - my_date
+      values:
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: LOCAL
+                        value: current-date[]
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: DATETIME_EXPRESSION
+                datetime_expression:
+                  left:
+                    term:
+                      factor:
+                        time_zone: 'UTC'
+                        value: literal['2001-01-01']
+# INSERT INTO using interval value expressions
+>INSERT INTO t1 (num_seconds) VALUES ('2001-01-01' DAY TO SECOND)
+statements:
+  - type: INSERT
+    insert_statement:
+      table_name: t1
+      columns:
+        - num_seconds
+      values:
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: literal['2001-01-01'] DAY TO SECOND
+# INSERT INTO using numeric value expressions
+>INSERT INTO t1 (num_seconds) VALUES (1 + (2 * 3))
+statements:
+  - type: INSERT
+    insert_statement:
+      table_name: t1
+      columns:
+        - num_seconds
+      values:
+        - row_value_constructor:
+            type: ELEMENT
+            element:
+              type: VALUE_EXPRESSION
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary:
+                            type: VALUE
+                            value: literal[1]
+                  op: ADD
+                  right:
+                    term:
+                      left:
+                        factor:
+                          primary:
+                            type: VALUE
+                            value: (numeric-expression[literal[2] * literal[3]])

--- a/tests/grammar/ansi-92/interval-expressions.test
+++ b/tests/grammar/ansi-92/interval-expressions.test
@@ -2,217 +2,226 @@
 >SELECT a YEAR FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] YEAR
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] YEAR
+        referenced_tables:
+          - t1
 # Simple interval value expression with non-second interval qualifier with a
 # leading precision
 >SELECT a DAY(2) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] DAY(2)
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] DAY(2)
+        referenced_tables:
+          - t1
 # Simple interval value expression with second interval qualifier with a
 # leading precision and no fractional precision
 >SELECT a SECOND(2) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] SECOND(2)
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] SECOND(2)
+        referenced_tables:
+          - t1
 # Simple interval value expression with second interval qualifier with a
 # leading precision and no fractional precision
 >SELECT a SECOND(2, 5) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] SECOND(2, 5)
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] SECOND(2, 5)
+        referenced_tables:
+          - t1
 # interval value expression with start and end non-second interval qualifier
 # with no precision specifiers
 >SELECT a YEAR TO MONTH FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] YEAR TO MONTH
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] YEAR TO MONTH
+        referenced_tables:
+          - t1
 # interval value expression with start non-second and end second interval
 # qualifier with no precision specifiers
 >SELECT a DAY TO SECOND FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] DAY TO SECOND
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] DAY TO SECOND
+        referenced_tables:
+          - t1
 # interval value expression with start non-second and end second interval
 # qualifier with a second fractional precision specifier
 >SELECT a DAY TO SECOND(5) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] DAY TO SECOND(0, 5)
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] DAY TO SECOND(0, 5)
+        referenced_tables:
+          - t1
 # interval value expression that operates on an interval term with a numeric
 # factor
 >SELECT a YEAR * 12, a YEAR / 2, a MONTH / (12 / b) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] YEAR
-                    op: MULTIPLY
-                    right:
-                      factor:
-                        primary:
-                          type: VALUE
-                          value: literal[12]
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] YEAR
-                    op: DIVIDE
-                    right:
-                      factor:
-                        primary:
-                          type: VALUE
-                          value: literal[2]
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] MONTH
-                    op: DIVIDE
-                    right:
-                      factor:
-                        primary:
-                          type: VALUE
-                          value: (numeric-expression[literal[12] / column-reference[b]])
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] YEAR
+                      op: MULTIPLY
+                      right:
+                        factor:
+                          primary:
+                            type: VALUE
+                            value: literal[12]
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] YEAR
+                      op: DIVIDE
+                      right:
+                        factor:
+                          primary:
+                            type: VALUE
+                            value: literal[2]
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] MONTH
+                      op: DIVIDE
+                      right:
+                        factor:
+                          primary:
+                            type: VALUE
+                            value: (numeric-expression[literal[12] / column-reference[b]])
+        referenced_tables:
+          - t1
 # interval value expression that uses addition and subtraction operators on
 # interval terms
 >SELECT a YEAR + 12 YEAR, created_on DAY TO SECOND - updated_on DAY TO SECOND from t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[a] YEAR
-                op: ADD
-                right:
-                  term:
-                    left:
-                      factor:
-                        primary: literal[12] YEAR
-        - derived_column:
-            value_expression:
-              type: INTERVAL_EXPRESSION
-              interval_expression:
-                left:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[created_on] DAY TO SECOND
-                op: SUBTRACT
-                right:
-                  term:
-                    left:
-                      factor:
-                        primary: column-reference[updated_on] DAY TO SECOND
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[a] YEAR
+                  op: ADD
+                  right:
+                    term:
+                      left:
+                        factor:
+                          primary: literal[12] YEAR
+          - derived_column:
+              value_expression:
+                type: INTERVAL_EXPRESSION
+                interval_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[created_on] DAY TO SECOND
+                  op: SUBTRACT
+                  right:
+                    term:
+                      left:
+                        factor:
+                          primary: column-reference[updated_on] DAY TO SECOND
+        referenced_tables:
+          - t1

--- a/tests/grammar/ansi-92/joins.test
+++ b/tests/grammar/ansi-92/joins.test
@@ -8,129 +8,142 @@ SELECT * FROM t1 CROSS t2
 >SELECT * FROM t1 CROSS JOIN t2
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - cross-join[t1,t2]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - cross-join[t1,t2]
 # INNER JOIN two normal tables WITHOUT the INNER symbol
 >SELECT * FROM t1 JOIN t2 ON t1.id = t2.t1_id
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # INNER JOIN two normal tables WITH the INNER symbol
 >SELECT * FROM t1 INNER JOIN t2 ON t1.id = t2.t1_id
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # INNER JOIN two normal tables with no join condition
 >SELECT * FROM t1 JOIN t2
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - inner-join[t1,t2]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - inner-join[t1,t2]
 # LEFT JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.t1_id
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # LEFT JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # RIGHT JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 RIGHT JOIN t2 ON t1.id = t2.t1_id
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # RIGHT JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # FULL OUTER JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 FULL JOIN t2 ON t1.id = t2.t1_id
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # FULL OUTER JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
 # JOIN with USING clause
 >SELECT * FROM t1 JOIN t2 USING (id)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - inner-join[t1,t2,using[id]]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - inner-join[t1,t2,using[id]]
 # NATURAL JOIN
 >SELECT * FROM t1 NATURAL JOIN t2
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - natural-join[t1,t2]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - natural-join[t1,t2]
 # UNION JOIN of two tables
 >SELECT * FROM t1 UNION JOIN t2
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - union-join[t1,t2]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - union-join[t1,t2]

--- a/tests/grammar/ansi-92/numeric-expressions.test
+++ b/tests/grammar/ansi-92/numeric-expressions.test
@@ -467,7 +467,9 @@ statements:
                     factor:
                       primary:
                         type: FUNCTION
-                        function: char-length[column-reference[a]]
+                        function:
+                          type: CHAR_LENGTH
+                          operand: column-reference[a]
         - derived_column:
             value_expression:
               type: NUMERIC_EXPRESSION
@@ -478,7 +480,9 @@ statements:
                       factor:
                         primary:
                           type: FUNCTION
-                          function: char-length[column-reference[a]]
+                          function:
+                            type: CHAR_LENGTH
+                            operand: column-reference[a]
                 op: ADD
                 right:
                   term:
@@ -504,7 +508,9 @@ statements:
                     factor:
                       primary:
                         type: FUNCTION
-                        function: bit-length[column-reference[a]]
+                        function:
+                          type: BIT_LENGTH
+                          operand: column-reference[a]
         - derived_column:
             value_expression:
               type: NUMERIC_EXPRESSION
@@ -514,7 +520,9 @@ statements:
                     factor:
                       primary:
                         type: FUNCTION
-                        function: octet-length[column-reference[a]]
+                        function:
+                          type: OCTET_LENGTH
+                          operand: column-reference[a]
       referenced_tables:
         - t1
 # Use of EXTRACT numeric function
@@ -532,7 +540,10 @@ statements:
                     factor:
                       primary:
                         type: FUNCTION
-                        function: extract[YEAR FROM datetime-expression[column-reference[a] AT LOCAL]]
+                        function:
+                          type: EXTRACT
+                          field: YEAR
+                          source: datetime-expression[column-reference[a] AT LOCAL]
       referenced_tables:
         - t1
 # Use of POSITION numeric function
@@ -550,6 +561,9 @@ statements:
                     factor:
                       primary:
                         type: FUNCTION
-                        function: position[literal['123'] IN column-reference[a]]
+                        function:
+                          type: POSITION
+                          find: literal['123']
+                          in: column-reference[a]
       referenced_tables:
         - t1

--- a/tests/grammar/ansi-92/numeric-expressions.test
+++ b/tests/grammar/ansi-92/numeric-expressions.test
@@ -2,20 +2,21 @@
 >SELECT 1 FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal[1]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: literal[1]
+        referenced_tables:
+          - t1
 # Simple addition of literal number to column reference
 >UPDATE t1 SET x = 1 WHERE a = (2 + b)
 statements:
@@ -230,251 +231,246 @@ statements:
 >SELECT USER, CURRENT_USER, SESSION_USER, SYSTEM_USER, VALUE FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: USER
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: CURRENT_USER
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: SESSION_USER
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: SYSTEM_USER
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: VALUE
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: USER
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: CURRENT_USER
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: SESSION_USER
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: SYSTEM_USER
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: VALUE
+        referenced_tables:
+          - t1
 # COUNT set function specifications
 >SELECT COUNT(*), COUNT(DISTINCT a), COUNT(a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: COUNT(*)
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: COUNT(DISTINCT column-reference[a])
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: COUNT(column-reference[a])
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: COUNT(*)
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: COUNT(DISTINCT column-reference[a])
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: COUNT(column-reference[a])
+        referenced_tables:
+          - t1
 # SUM set function specifications
 >SELECT SUM(DISTINCT a), SUM(a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: SUM(DISTINCT column-reference[a])
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: SUM(column-reference[a])
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: SUM(DISTINCT column-reference[a])
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: SUM(column-reference[a])
+        referenced_tables:
+          - t1
 # AVG set function specifications
 >SELECT AVG(DISTINCT a), AVG(a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: AVG(DISTINCT column-reference[a])
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: AVG(column-reference[a])
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: AVG(DISTINCT column-reference[a])
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: AVG(column-reference[a])
+        referenced_tables:
+          - t1
 # MIN set function specifications
 >SELECT MIN(DISTINCT a), MIN(a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: MIN(DISTINCT column-reference[a])
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: MIN(column-reference[a])
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: MIN(DISTINCT column-reference[a])
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: MIN(column-reference[a])
+        referenced_tables:
+          - t1
 # MAX set function specifications
 >SELECT MAX(DISTINCT a), MAX(a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: MAX(DISTINCT column-reference[a])
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: MAX(column-reference[a])
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: MAX(DISTINCT column-reference[a])
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: MAX(column-reference[a])
+        referenced_tables:
+          - t1
 # Nested set function specifications
 >SELECT MAX(COUNT(a)) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: MAX(COUNT(column-reference[a]))
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: MAX(COUNT(column-reference[a]))
+        referenced_tables:
+          - t1
 # Use of CHAR_LENGTH and CHARACTER_LENGTH numeric functions
 >SELECT CHAR_LENGTH(a), CHARACTER_LENGTH(a) + 1 FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: FUNCTION
-                        function:
-                          type: CHAR_LENGTH
-                          operand: column-reference[a]
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                left:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
                   term:
                     left:
                       factor:
@@ -483,87 +479,103 @@ statements:
                           function:
                             type: CHAR_LENGTH
                             operand: column-reference[a]
-                op: ADD
-                right:
-                  term:
-                    left:
-                      factor:
-                        primary:
-                          type: VALUE
-                          value: literal[1]
-      referenced_tables:
-        - t1
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  left:
+                    term:
+                      left:
+                        factor:
+                          primary:
+                            type: FUNCTION
+                            function:
+                              type: CHAR_LENGTH
+                              operand: column-reference[a]
+                  op: ADD
+                  right:
+                    term:
+                      left:
+                        factor:
+                          primary:
+                            type: VALUE
+                            value: literal[1]
+        referenced_tables:
+          - t1
 # Use of BIT_LENGTH and OCTET_LENGTH numeric functions
 >SELECT BIT_LENGTH(a), OCTET_LENGTH(a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: FUNCTION
-                        function:
-                          type: BIT_LENGTH
-                          operand: column-reference[a]
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: FUNCTION
-                        function:
-                          type: OCTET_LENGTH
-                          operand: column-reference[a]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: FUNCTION
+                          function:
+                            type: BIT_LENGTH
+                            operand: column-reference[a]
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: FUNCTION
+                          function:
+                            type: OCTET_LENGTH
+                            operand: column-reference[a]
+        referenced_tables:
+          - t1
 # Use of EXTRACT numeric function
 >SELECT EXTRACT(YEAR FROM a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: FUNCTION
-                        function:
-                          type: EXTRACT
-                          field: YEAR
-                          source: datetime-expression[column-reference[a] AT LOCAL]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: FUNCTION
+                          function:
+                            type: EXTRACT
+                            field: YEAR
+                            source: datetime-expression[column-reference[a] AT LOCAL]
+        referenced_tables:
+          - t1
 # Use of POSITION numeric function
 >SELECT POSITION('123' IN a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: FUNCTION
-                        function:
-                          type: POSITION
-                          find: literal['123']
-                          in: column-reference[a]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: FUNCTION
+                          function:
+                            type: POSITION
+                            find: literal['123']
+                            in: column-reference[a]
+        referenced_tables:
+          - t1

--- a/tests/grammar/ansi-92/numeric-expressions.test
+++ b/tests/grammar/ansi-92/numeric-expressions.test
@@ -21,212 +21,217 @@ statements:
 >UPDATE t1 SET x = 1 WHERE a = (2 + b)
 statements:
   - type: UPDATE
-    table_name: t1
-    set_columns:
-      x: literal[1]
-    where:
-      search_condition:
-        terms:
-          - factor:
-              predicate:
-                type: COMPARISON
-                op: EQUAL
-                left:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: column-reference[a]
-                right:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: (numeric-expression[literal[2] + column-reference[b]])
+    update_statement:
+      table_name: t1
+      set_columns:
+        x: literal[1]
+      where:
+        search_condition:
+          terms:
+            - factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: column-reference[a]
+                  right:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: (numeric-expression[literal[2] + column-reference[b]])
 # Simple subtraction of literal number from column reference
 >UPDATE t1 SET x = 1 WHERE a = (b - 2)
 statements:
   - type: UPDATE
-    table_name: t1
-    set_columns:
-      x: literal[1]
-    where:
-      search_condition:
-        terms:
-          - factor:
-              predicate:
-                type: COMPARISON
-                op: EQUAL
-                left:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: column-reference[a]
-                right:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: (numeric-expression[column-reference[b] - literal[2]])
+    update_statement:
+      table_name: t1
+      set_columns:
+        x: literal[1]
+      where:
+        search_condition:
+          terms:
+            - factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: column-reference[a]
+                  right:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: (numeric-expression[column-reference[b] - literal[2]])
 # Simple multiplication of two literals
 >UPDATE t1 SET x = 1 WHERE a = (2 * 1)
 statements:
   - type: UPDATE
-    table_name: t1
-    set_columns:
-      x: literal[1]
-    where:
-      search_condition:
-        terms:
-          - factor:
-              predicate:
-                type: COMPARISON
-                op: EQUAL
-                left:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: column-reference[a]
-                right:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: (numeric-expression[literal[2] * literal[1]])
+    update_statement:
+      table_name: t1
+      set_columns:
+        x: literal[1]
+      where:
+        search_condition:
+          terms:
+            - factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: column-reference[a]
+                  right:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: (numeric-expression[literal[2] * literal[1]])
 # Simple division of two literals
 >UPDATE t1 SET x = 1 WHERE a = (1 / 2)
 statements:
   - type: UPDATE
-    table_name: t1
-    set_columns:
-      x: literal[1]
-    where:
-      search_condition:
-        terms:
-          - factor:
-              predicate:
-                type: COMPARISON
-                op: EQUAL
-                left:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: column-reference[a]
-                right:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: (numeric-expression[literal[1] / literal[2]])
+    update_statement:
+      table_name: t1
+      set_columns:
+        x: literal[1]
+      where:
+        search_condition:
+          terms:
+            - factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: column-reference[a]
+                  right:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: (numeric-expression[literal[1] / literal[2]])
 # Addition of numeric expression to a literal
 >UPDATE t1 SET x = 1 WHERE a = (1 + (2 * 1))
 statements:
   - type: UPDATE
-    table_name: t1
-    set_columns:
-      x: literal[1]
-    where:
-      search_condition:
-        terms:
-          - factor:
-              predicate:
-                type: COMPARISON
-                op: EQUAL
-                left:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: column-reference[a]
-                right:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: (numeric-expression[literal[1] + (numeric-expression[literal[2] * literal[1]])])
+    update_statement:
+      table_name: t1
+      set_columns:
+        x: literal[1]
+      where:
+        search_condition:
+          terms:
+            - factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: column-reference[a]
+                  right:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: (numeric-expression[literal[1] + (numeric-expression[literal[2] * literal[1]])])
 # General value expression primaries
 >SELECT USER, CURRENT_USER, SESSION_USER, SYSTEM_USER, VALUE FROM t1
 statements:

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -2,184 +2,155 @@
 >SELECT * FROM t1 WHERE a = 10
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[10]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[10]
 # anti-equality comparison predicate
 >SELECT * FROM t1 WHERE a <> 10
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: NOT_EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[10]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: NOT_EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[10]
 # Order of value expressions should not matter in equality comparison
 >SELECT * FROM t1 WHERE 10 = a
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[10]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[10]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
 # Compound predicate with AND of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 AND b = 2
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[1]
-              and:
-                factor:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
                   predicate:
                     type: COMPARISON
                     op: EQUAL
@@ -196,7 +167,7 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[b]
+                                      value: column-reference[a]
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -210,131 +181,87 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[2]
+                                      value: literal[1]
+                and:
+                  factor:
+                    predicate:
+                      type: COMPARISON
+                      op: EQUAL
+                      left:
+                        row_value_constructor:
+                          type: ELEMENT
+                          element:
+                            type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[b]
+                      right:
+                        row_value_constructor:
+                          type: ELEMENT
+                          element:
+                            type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: literal[2]
 # Compound predicate with OR of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 OR b = 2
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[1]
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[b]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[2]
-# Compound predicate with both AND and OR operators
->SELECT * FROM t1 WHERE a = 1 AND b = 2 OR c = 3
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[1]
-              and:
-                factor:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[1]
+              - factor:
                   predicate:
                     type: COMPARISON
                     op: EQUAL
@@ -366,118 +293,86 @@ statements:
                                     primary:
                                       type: VALUE
                                       value: literal[2]
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[c]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[3]
-# Compound predicate with both OR and AND operators. The AND should take
-# precedence
->SELECT * FROM t1 WHERE a = 1 OR b = 2 AND c = 3
+# Compound predicate with both AND and OR operators
+>SELECT * FROM t1 WHERE a = 1 AND b = 2 OR c = 3
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[1]
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[b]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[2]
-              and:
-                factor:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[1]
+                and:
+                  factor:
+                    predicate:
+                      type: COMPARISON
+                      op: EQUAL
+                      left:
+                        row_value_constructor:
+                          type: ELEMENT
+                          element:
+                            type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[b]
+                      right:
+                        row_value_constructor:
+                          type: ELEMENT
+                          element:
+                            type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: literal[2]
+              - factor:
                   predicate:
                     type: COMPARISON
                     op: EQUAL
@@ -509,157 +404,448 @@ statements:
                                     primary:
                                       type: VALUE
                                       value: literal[3]
+# Compound predicate with both OR and AND operators. The AND should take
+# precedence
+>SELECT * FROM t1 WHERE a = 1 OR b = 2 AND c = 3
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[1]
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[b]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[2]
+                and:
+                  factor:
+                    predicate:
+                      type: COMPARISON
+                      op: EQUAL
+                      left:
+                        row_value_constructor:
+                          type: ELEMENT
+                          element:
+                            type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[c]
+                      right:
+                        row_value_constructor:
+                          type: ELEMENT
+                          element:
+                            type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: literal[3]
 # Compound predicate with both AND and OR operators using parens for precedence
 # override
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[1]
+                and:
+                  factor:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
                               left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
+                                row_value_constructor:
+                                  type: ELEMENT
+                                  element:
+                                    type: VALUE_EXPRESSION
+                                    value_expression:
+                                      type: NUMERIC_EXPRESSION
+                                      numeric_expression:
+                                        term:
+                                          left:
+                                            factor:
+                                              primary:
+                                                type: VALUE
+                                                value: column-reference[b]
+                              right:
+                                row_value_constructor:
+                                  type: ELEMENT
+                                  element:
+                                    type: VALUE_EXPRESSION
+                                    value_expression:
+                                      type: NUMERIC_EXPRESSION
+                                      numeric_expression:
+                                        term:
+                                          left:
+                                            factor:
+                                              primary:
+                                                type: VALUE
+                                                value: literal[2]
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
                               left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[1]
-              and:
-                factor:
-                  search_condition:
-                    terms:
-                      - factor:
-                          predicate:
-                            type: COMPARISON
-                            op: EQUAL
-                            left:
-                              row_value_constructor:
-                                type: ELEMENT
-                                element:
-                                  type: VALUE_EXPRESSION
-                                  value_expression:
-                                    type: NUMERIC_EXPRESSION
-                                    numeric_expression:
-                                      term:
-                                        left:
-                                          factor:
-                                            primary:
-                                              type: VALUE
-                                              value: column-reference[b]
-                            right:
-                              row_value_constructor:
-                                type: ELEMENT
-                                element:
-                                  type: VALUE_EXPRESSION
-                                  value_expression:
-                                    type: NUMERIC_EXPRESSION
-                                    numeric_expression:
-                                      term:
-                                        left:
-                                          factor:
-                                            primary:
-                                              type: VALUE
-                                              value: literal[2]
-                      - factor:
-                          predicate:
-                            type: COMPARISON
-                            op: EQUAL
-                            left:
-                              row_value_constructor:
-                                type: ELEMENT
-                                element:
-                                  type: VALUE_EXPRESSION
-                                  value_expression:
-                                    type: NUMERIC_EXPRESSION
-                                    numeric_expression:
-                                      term:
-                                        left:
-                                          factor:
-                                            primary:
-                                              type: VALUE
-                                              value: column-reference[c]
-                            right:
-                              row_value_constructor:
-                                type: ELEMENT
-                                element:
-                                  type: VALUE_EXPRESSION
-                                  value_expression:
-                                    type: NUMERIC_EXPRESSION
-                                    numeric_expression:
-                                      term:
-                                        left:
-                                          factor:
-                                            primary:
-                                              type: VALUE
-                                              value: literal[3]
+                                row_value_constructor:
+                                  type: ELEMENT
+                                  element:
+                                    type: VALUE_EXPRESSION
+                                    value_expression:
+                                      type: NUMERIC_EXPRESSION
+                                      numeric_expression:
+                                        term:
+                                          left:
+                                            factor:
+                                              primary:
+                                                type: VALUE
+                                                value: column-reference[c]
+                              right:
+                                row_value_constructor:
+                                  type: ELEMENT
+                                  element:
+                                    type: VALUE_EXPRESSION
+                                    value_expression:
+                                      type: NUMERIC_EXPRESSION
+                                      numeric_expression:
+                                        term:
+                                          left:
+                                            factor:
+                                              primary:
+                                                type: VALUE
+                                                value: literal[3]
 # Multiple nested search conditions using parens for precedence
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3 AND (d = 4 OR e = 5))
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[1]
+                and:
+                  factor:
+                    search_condition:
+                      terms:
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
                               left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
+                                row_value_constructor:
+                                  type: ELEMENT
+                                  element:
+                                    type: VALUE_EXPRESSION
+                                    value_expression:
+                                      type: NUMERIC_EXPRESSION
+                                      numeric_expression:
+                                        term:
+                                          left:
+                                            factor:
+                                              primary:
+                                                type: VALUE
+                                                value: column-reference[b]
+                              right:
+                                row_value_constructor:
+                                  type: ELEMENT
+                                  element:
+                                    type: VALUE_EXPRESSION
+                                    value_expression:
+                                      type: NUMERIC_EXPRESSION
+                                      numeric_expression:
+                                        term:
+                                          left:
+                                            factor:
+                                              primary:
+                                                type: VALUE
+                                                value: literal[2]
+                        - factor:
+                            predicate:
+                              type: COMPARISON
+                              op: EQUAL
+                              left:
+                                row_value_constructor:
+                                  type: ELEMENT
+                                  element:
+                                    type: VALUE_EXPRESSION
+                                    value_expression:
+                                      type: NUMERIC_EXPRESSION
+                                      numeric_expression:
+                                        term:
+                                          left:
+                                            factor:
+                                              primary:
+                                                type: VALUE
+                                                value: column-reference[c]
+                              right:
+                                row_value_constructor:
+                                  type: ELEMENT
+                                  element:
+                                    type: VALUE_EXPRESSION
+                                    value_expression:
+                                      type: NUMERIC_EXPRESSION
+                                      numeric_expression:
+                                        term:
+                                          left:
+                                            factor:
+                                              primary:
+                                                type: VALUE
+                                                value: literal[3]
+                          and:
+                            factor:
+                              search_condition:
+                                terms:
+                                  - factor:
+                                      predicate:
+                                        type: COMPARISON
+                                        op: EQUAL
+                                        left:
+                                          row_value_constructor:
+                                            type: ELEMENT
+                                            element:
+                                              type: VALUE_EXPRESSION
+                                              value_expression:
+                                                type: NUMERIC_EXPRESSION
+                                                numeric_expression:
+                                                  term:
+                                                    left:
+                                                      factor:
+                                                        primary:
+                                                          type: VALUE
+                                                          value: column-reference[d]
+                                        right:
+                                          row_value_constructor:
+                                            type: ELEMENT
+                                            element:
+                                              type: VALUE_EXPRESSION
+                                              value_expression:
+                                                type: NUMERIC_EXPRESSION
+                                                numeric_expression:
+                                                  term:
+                                                    left:
+                                                      factor:
+                                                        primary:
+                                                          type: VALUE
+                                                          value: literal[4]
+                                  - factor:
+                                      predicate:
+                                        type: COMPARISON
+                                        op: EQUAL
+                                        left:
+                                          row_value_constructor:
+                                            type: ELEMENT
+                                            element:
+                                              type: VALUE_EXPRESSION
+                                              value_expression:
+                                                type: NUMERIC_EXPRESSION
+                                                numeric_expression:
+                                                  term:
+                                                    left:
+                                                      factor:
+                                                        primary:
+                                                          type: VALUE
+                                                          value: column-reference[e]
+                                        right:
+                                          row_value_constructor:
+                                            type: ELEMENT
+                                            element:
+                                              type: VALUE_EXPRESSION
+                                              value_expression:
+                                                type: NUMERIC_EXPRESSION
+                                                numeric_expression:
+                                                  term:
+                                                    left:
+                                                      factor:
+                                                        primary:
+                                                          type: VALUE
+                                                          value: literal[5]
+# IN (<value list>) operator with single value
+>SELECT * FROM t1 WHERE a IN (1)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: IN_VALUES
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    values:
+                      - value_expression:
                           type: NUMERIC_EXPRESSION
                           numeric_expression:
                             term:
@@ -668,76 +854,1116 @@ statements:
                                   primary:
                                     type: VALUE
                                     value: literal[1]
-              and:
-                factor:
-                  search_condition:
-                    terms:
-                      - factor:
-                          predicate:
-                            type: COMPARISON
-                            op: EQUAL
+# Negate of IN (<value list>) operator with single value
+>SELECT * FROM t1 WHERE a NOT IN (1)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: IN_VALUES
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    negate: true
+                    values:
+                      - value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: literal[1]
+# top-level negation of IN (<value list>) operator with single value
+>SELECT * FROM t1 WHERE NOT a IN (1)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: IN_VALUES
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    values:
+                      - value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: literal[1]
+                  negate: true
+# double-negation of IN (<value list>) operator with single value
+>SELECT * FROM t1 WHERE NOT a NOT IN (1)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: IN_VALUES
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    negate: true
+                    values:
+                      - value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: literal[1]
+                  negate: true
+# IN (<value list>) operator with multiple value
+>SELECT * FROM t1 WHERE a IN (1, 2, 3)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: IN_VALUES
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    values:
+                      - value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: literal[1]
+                      - value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: literal[2]
+                      - value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: literal[3]
+# IN (<value list>) operator with complex value expressions
+>SELECT * FROM t1 WHERE a IN (1 - b, CHAR_LENGTH(b))
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: IN_VALUES
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    values:
+                      - value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
                             left:
-                              row_value_constructor:
-                                type: ELEMENT
-                                element:
-                                  type: VALUE_EXPRESSION
-                                  value_expression:
-                                    type: NUMERIC_EXPRESSION
-                                    numeric_expression:
-                                      term:
-                                        left:
-                                          factor:
-                                            primary:
-                                              type: VALUE
-                                              value: column-reference[b]
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[1]
+                            op: SUBTRACT
                             right:
-                              row_value_constructor:
-                                type: ELEMENT
-                                element:
-                                  type: VALUE_EXPRESSION
-                                  value_expression:
-                                    type: NUMERIC_EXPRESSION
-                                    numeric_expression:
-                                      term:
-                                        left:
-                                          factor:
-                                            primary:
-                                              type: VALUE
-                                              value: literal[2]
-                      - factor:
-                          predicate:
-                            type: COMPARISON
-                            op: EQUAL
-                            left:
-                              row_value_constructor:
-                                type: ELEMENT
-                                element:
-                                  type: VALUE_EXPRESSION
-                                  value_expression:
-                                    type: NUMERIC_EXPRESSION
-                                    numeric_expression:
-                                      term:
-                                        left:
-                                          factor:
-                                            primary:
-                                              type: VALUE
-                                              value: column-reference[c]
-                            right:
-                              row_value_constructor:
-                                type: ELEMENT
-                                element:
-                                  type: VALUE_EXPRESSION
-                                  value_expression:
-                                    type: NUMERIC_EXPRESSION
-                                    numeric_expression:
-                                      term:
-                                        left:
-                                          factor:
-                                            primary:
-                                              type: VALUE
-                                              value: literal[3]
-                        and:
-                          factor:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[b]
+                      - value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: FUNCTION
+                                    function:
+                                      type: CHAR_LENGTH
+                                      operand: column-reference[b]
+# IN (<subquery>) operator
+>SELECT * FROM t1 WHERE a IN (SELECT t1_a FROM t2)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: IN_SUBQUERY
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1_a]
+                      referenced_tables:
+                        - t2
+# EXISTS (<subquery>) predicate
+>SELECT * FROM t1 WHERE EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: EXISTS
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1_id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+# NOT EXISTS (<subquery>) predicate
+>SELECT * FROM t1 WHERE NOT EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: EXISTS
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1_id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+                    negate: true
+# <row> MATCH (<subquery>) predicate
+>SELECT * FROM t1 WHERE id MATCH (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: MATCH
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[id]
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1_id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+# <row> MATCH (<subquery>) predicate explicit FULL
+>SELECT * FROM t1 WHERE id MATCH FULL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: MATCH
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[id]
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1_id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+# <row> MATCH (<subquery>) predicate with UNIQUE
+>SELECT * FROM t1 WHERE id MATCH UNIQUE (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: MATCH
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[id]
+                    unique: true
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1_id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+# <row> MATCH (<subquery>) predicate explicit PARTIAL
+>SELECT * FROM t1 WHERE id MATCH PARTIAL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: MATCH
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[id]
+                    partial: true
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1_id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+# LIKE predicate with simple column comparison with string
+>SELECT * FROM t1 WHERE a LIKE 's%'
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: LIKE
+                    match:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    pattern:
+                      value_expression:
+                        type: STRING_EXPRESSION
+                        character_expression:
+                          factors:
+                            - primary:
+                                value: literal['s%']
+# LIKE predicate with concatenated column comparison with string
+>SELECT * FROM t1 WHERE a LIKE b || '%'
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: LIKE
+                    match:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    pattern:
+                      value_expression:
+                        type: STRING_EXPRESSION
+                        character_expression:
+                          factors:
+                            - primary:
+                                value: column-reference[b]
+                            - primary:
+                                value: literal['%']
+# OVERLAPS predicate with date columns from multiple tables
+>SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+          - t2
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: OVERLAPS
+                    left:
+                      row_value_constructor:
+                        type: LIST
+                        elements:
+                          - type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1.start]
+                          - type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t1.end]
+                    right:
+                      row_value_constructor:
+                        type: LIST
+                        elements:
+                          - type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t2.start]
+                          - type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t2.end]
+# the UNIQUE predicate returns a match when the correlation returns one and
+# only one row
+>SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: UNIQUE
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t2.id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t2.t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+# negated UNIQUE predicate
+>SELECT * FROM t1 WHERE NOT UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: UNIQUE
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t2.id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t2.t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+                    negate: true
+# Combine EXISTS and UNIQUE predicate
+>SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id) AND EXISTS (SELECT t3.id FROM t3 WHERE t3.t1_id = t1.id);
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: UNIQUE
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t2.id]
+                      referenced_tables:
+                        - t2
+                      where:
+                        search_condition:
+                          terms:
+                            - factor:
+                                predicate:
+                                  type: COMPARISON
+                                  op: EQUAL
+                                  left:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t2.t1_id]
+                                  right:
+                                    row_value_constructor:
+                                      type: ELEMENT
+                                      element:
+                                        type: VALUE_EXPRESSION
+                                        value_expression:
+                                          type: NUMERIC_EXPRESSION
+                                          numeric_expression:
+                                            term:
+                                              left:
+                                                factor:
+                                                  primary:
+                                                    type: VALUE
+                                                    value: column-reference[t1.id]
+                  and:
+                    factor:
+                      predicate:
+                        type: EXISTS
+                        query:
+                          selected_columns:
+                            - derived_column:
+                                value_expression:
+                                  type: NUMERIC_EXPRESSION
+                                  numeric_expression:
+                                    term:
+                                      left:
+                                        factor:
+                                          primary:
+                                            type: VALUE
+                                            value: column-reference[t3.id]
+                          referenced_tables:
+                            - t3
+                          where:
                             search_condition:
                               terms:
                                 - factor:
@@ -757,7 +1983,7 @@ statements:
                                                     factor:
                                                       primary:
                                                         type: VALUE
-                                                        value: column-reference[d]
+                                                        value: column-reference[t3.t1_id]
                                       right:
                                         row_value_constructor:
                                           type: ELEMENT
@@ -771,912 +1997,31 @@ statements:
                                                     factor:
                                                       primary:
                                                         type: VALUE
-                                                        value: literal[4]
-                                - factor:
-                                    predicate:
-                                      type: COMPARISON
-                                      op: EQUAL
-                                      left:
-                                        row_value_constructor:
-                                          type: ELEMENT
-                                          element:
-                                            type: VALUE_EXPRESSION
-                                            value_expression:
-                                              type: NUMERIC_EXPRESSION
-                                              numeric_expression:
-                                                term:
-                                                  left:
-                                                    factor:
-                                                      primary:
-                                                        type: VALUE
-                                                        value: column-reference[e]
-                                      right:
-                                        row_value_constructor:
-                                          type: ELEMENT
-                                          element:
-                                            type: VALUE_EXPRESSION
-                                            value_expression:
-                                              type: NUMERIC_EXPRESSION
-                                              numeric_expression:
-                                                term:
-                                                  left:
-                                                    factor:
-                                                      primary:
-                                                        type: VALUE
-                                                        value: literal[5]
-# IN (<value list>) operator with single value
->SELECT * FROM t1 WHERE a IN (1)
+                                                        value: column-reference[t1.id]
+# quantified comparison predicates are like comparison predicates with an
+# ANY|ALL|SOME quantifier
+>SELECT * FROM t1 WHERE t1.start > ALL (SELECT t2.start FROM t2)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: IN_VALUES
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  values:
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[1]
-# Negate of IN (<value list>) operator with single value
->SELECT * FROM t1 WHERE a NOT IN (1)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: IN_VALUES
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  negate: true
-                  values:
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[1]
-# top-level negation of IN (<value list>) operator with single value
->SELECT * FROM t1 WHERE NOT a IN (1)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: IN_VALUES
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  values:
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[1]
-                negate: true
-# double-negation of IN (<value list>) operator with single value
->SELECT * FROM t1 WHERE NOT a NOT IN (1)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: IN_VALUES
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  negate: true
-                  values:
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[1]
-                negate: true
-# IN (<value list>) operator with multiple value
->SELECT * FROM t1 WHERE a IN (1, 2, 3)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: IN_VALUES
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  values:
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[1]
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[2]
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[3]
-# IN (<value list>) operator with complex value expressions
->SELECT * FROM t1 WHERE a IN (1 - b, CHAR_LENGTH(b))
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: IN_VALUES
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  values:
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          left:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: literal[1]
-                          op: SUBTRACT
-                          right:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[b]
-                    - value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: FUNCTION
-                                  function:
-                                    type: CHAR_LENGTH
-                                    operand: column-reference[b]
-# IN (<subquery>) operator
->SELECT * FROM t1 WHERE a IN (SELECT t1_a FROM t2)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: IN_SUBQUERY
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t1_a]
-                    referenced_tables:
-                      - t2
-# EXISTS (<subquery>) predicate
->SELECT * FROM t1 WHERE EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: EXISTS
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t1_id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-# NOT EXISTS (<subquery>) predicate
->SELECT * FROM t1 WHERE NOT EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: EXISTS
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t1_id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-                  negate: true
-# <row> MATCH (<subquery>) predicate
->SELECT * FROM t1 WHERE id MATCH (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: MATCH
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[id]
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t1_id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-# <row> MATCH (<subquery>) predicate explicit FULL
->SELECT * FROM t1 WHERE id MATCH FULL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: MATCH
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[id]
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t1_id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-# <row> MATCH (<subquery>) predicate with UNIQUE
->SELECT * FROM t1 WHERE id MATCH UNIQUE (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: MATCH
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[id]
-                  unique: true
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t1_id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-# <row> MATCH (<subquery>) predicate explicit PARTIAL
->SELECT * FROM t1 WHERE id MATCH PARTIAL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: MATCH
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[id]
-                  partial: true
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t1_id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-# LIKE predicate with simple column comparison with string
->SELECT * FROM t1 WHERE a LIKE 's%'
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: LIKE
-                  match:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  pattern:
-                    value_expression:
-                      type: STRING_EXPRESSION
-                      character_expression:
-                        factors:
-                          - primary:
-                              value: literal['s%']
-# LIKE predicate with concatenated column comparison with string
->SELECT * FROM t1 WHERE a LIKE b || '%'
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: LIKE
-                  match:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  pattern:
-                    value_expression:
-                      type: STRING_EXPRESSION
-                      character_expression:
-                        factors:
-                          - primary:
-                              value: column-reference[b]
-                          - primary:
-                              value: literal['%']
-# OVERLAPS predicate with date columns from multiple tables
->SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-        - t2
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: OVERLAPS
-                  left:
-                    row_value_constructor:
-                      type: LIST
-                      elements:
-                        - type: VALUE_EXPRESSION
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: QUANTIFIED_COMPARISON
+                    op: GREATER_THAN
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
                           value_expression:
                             type: NUMERIC_EXPRESSION
                             numeric_expression:
@@ -1686,372 +2031,44 @@ statements:
                                     primary:
                                       type: VALUE
                                       value: column-reference[t1.start]
-                        - type: VALUE_EXPRESSION
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t1.end]
-                  right:
-                    row_value_constructor:
-                      type: LIST
-                      elements:
-                        - type: VALUE_EXPRESSION
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t2.start]
-                        - type: VALUE_EXPRESSION
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t2.end]
-# the UNIQUE predicate returns a match when the correlation returns one and
-# only one row
->SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: UNIQUE
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t2.id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t2.t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-# negated UNIQUE predicate
->SELECT * FROM t1 WHERE NOT UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: UNIQUE
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t2.id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t2.t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-                  negate: true
-# Combine EXISTS and UNIQUE predicate
->SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id) AND EXISTS (SELECT t3.id FROM t3 WHERE t3.t1_id = t1.id);
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: UNIQUE
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t2.id]
-                    referenced_tables:
-                      - t2
-                    where:
-                      search_condition:
-                        terms:
-                          - factor:
-                              predicate:
-                                type: COMPARISON
-                                op: EQUAL
-                                left:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t2.t1_id]
-                                right:
-                                  row_value_constructor:
-                                    type: ELEMENT
-                                    element:
-                                      type: VALUE_EXPRESSION
-                                      value_expression:
-                                        type: NUMERIC_EXPRESSION
-                                        numeric_expression:
-                                          term:
-                                            left:
-                                              factor:
-                                                primary:
-                                                  type: VALUE
-                                                  value: column-reference[t1.id]
-                and:
-                  factor:
-                    predicate:
-                      type: EXISTS
-                      query:
-                        selected_columns:
-                          - derived_column:
-                              value_expression:
-                                type: NUMERIC_EXPRESSION
-                                numeric_expression:
-                                  term:
-                                    left:
-                                      factor:
-                                        primary:
-                                          type: VALUE
-                                          value: column-reference[t3.id]
-                        referenced_tables:
-                          - t3
-                        where:
-                          search_condition:
-                            terms:
-                              - factor:
-                                  predicate:
-                                    type: COMPARISON
-                                    op: EQUAL
-                                    left:
-                                      row_value_constructor:
-                                        type: ELEMENT
-                                        element:
-                                          type: VALUE_EXPRESSION
-                                          value_expression:
-                                            type: NUMERIC_EXPRESSION
-                                            numeric_expression:
-                                              term:
-                                                left:
-                                                  factor:
-                                                    primary:
-                                                      type: VALUE
-                                                      value: column-reference[t3.t1_id]
-                                    right:
-                                      row_value_constructor:
-                                        type: ELEMENT
-                                        element:
-                                          type: VALUE_EXPRESSION
-                                          value_expression:
-                                            type: NUMERIC_EXPRESSION
-                                            numeric_expression:
-                                              term:
-                                                left:
-                                                  factor:
-                                                    primary:
-                                                      type: VALUE
-                                                      value: column-reference[t1.id]
-# quantified comparison predicates are like comparison predicates with an
-# ANY|ALL|SOME quantifier
->SELECT * FROM t1 WHERE t1.start > ALL (SELECT t2.start FROM t2)
-statements:
-  - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: QUANTIFIED_COMPARISON
-                  op: GREATER_THAN
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[t1.start]
-                  quantifier: ALL
-                  query:
-                    selected_columns:
-                      - derived_column:
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[t2.start]
-                    referenced_tables:
-                      - t2
+                    quantifier: ALL
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t2.start]
+                      referenced_tables:
+                        - t2
 # quantified comparison predicate with ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= ANY (SELECT t2.start FROM t2)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: QUANTIFIED_COMPARISON
-                  op: LESS_THAN_OR_EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[t1.start]
-                  quantifier: ANY
-                  query:
-                    selected_columns:
-                      - derived_column:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: QUANTIFIED_COMPARISON
+                    op: LESS_THAN_OR_EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
                           value_expression:
                             type: NUMERIC_EXPRESSION
                             numeric_expression:
@@ -2060,44 +2077,45 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[t2.start]
-                    referenced_tables:
-                      - t2
+                                      value: column-reference[t1.start]
+                    quantifier: ANY
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t2.start]
+                      referenced_tables:
+                        - t2
 # quantified comparison predicate with SOME quantifier translated to ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= SOME (SELECT t2.start FROM t2)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: QUANTIFIED_COMPARISON
-                  op: LESS_THAN_OR_EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[t1.start]
-                  quantifier: ANY
-                  query:
-                    selected_columns:
-                      - derived_column:
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: QUANTIFIED_COMPARISON
+                    op: LESS_THAN_OR_EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
                           value_expression:
                             type: NUMERIC_EXPRESSION
                             numeric_expression:
@@ -2106,6 +2124,19 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[t2.start]
-                    referenced_tables:
-                      - t2
+                                      value: column-reference[t1.start]
+                    quantifier: ANY
+                    query:
+                      selected_columns:
+                        - derived_column:
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[t2.start]
+                      referenced_tables:
+                        - t2

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -1614,7 +1614,8 @@ statements:
                       type: STRING_EXPRESSION
                       character_expression:
                         factors:
-                          - primary: literal['s%']
+                          - primary:
+                              value: literal['s%']
 # LIKE predicate with concatenated column comparison with string
 >SELECT * FROM t1 WHERE a LIKE b || '%'
 statements:
@@ -1650,8 +1651,10 @@ statements:
                       type: STRING_EXPRESSION
                       character_expression:
                         factors:
-                          - primary: column-reference[b]
-                          - primary: literal['%']
+                          - primary:
+                              value: column-reference[b]
+                          - primary:
+                              value: literal['%']
 # OVERLAPS predicate with date columns from multiple tables
 >SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
 statements:

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -1614,7 +1614,7 @@ statements:
                       type: STRING_EXPRESSION
                       character_expression:
                         factors:
-                          - value: literal['s%']
+                          - primary: literal['s%']
 # LIKE predicate with concatenated column comparison with string
 >SELECT * FROM t1 WHERE a LIKE b || '%'
 statements:
@@ -1650,8 +1650,8 @@ statements:
                       type: STRING_EXPRESSION
                       character_expression:
                         factors:
-                          - value: column-reference[b]
-                          - value: literal['%']
+                          - primary: column-reference[b]
+                          - primary: literal['%']
 # OVERLAPS predicate with date columns from multiple tables
 >SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
 statements:

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -1083,7 +1083,9 @@ statements:
                               factor:
                                 primary:
                                   type: FUNCTION
-                                  function: char-length[column-reference[b]]
+                                  function:
+                                    type: CHAR_LENGTH
+                                    operand: column-reference[b]
 # IN (<subquery>) operator
 >SELECT * FROM t1 WHERE a IN (SELECT t1_a FROM t2)
 statements:

--- a/tests/grammar/ansi-92/row-value-constructors.test
+++ b/tests/grammar/ansi-92/row-value-constructors.test
@@ -3,248 +3,253 @@
 >SELECT  * FROM t1 WHERE (a, b) = (b, a)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: LIST
-                      elements:
-                        - type: VALUE_EXPRESSION
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[a]
-                        - type: VALUE_EXPRESSION
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[b]
-                  right:
-                    row_value_constructor:
-                      type: LIST
-                      elements:
-                        - type: VALUE_EXPRESSION
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[b]
-                        - type: VALUE_EXPRESSION
-                          value_expression:
-                            type: NUMERIC_EXPRESSION
-                            numeric_expression:
-                              term:
-                                left:
-                                  factor:
-                                    primary:
-                                      type: VALUE
-                                      value: column-reference[a]
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: LIST
+                        elements:
+                          - type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[a]
+                          - type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[b]
+                    right:
+                      row_value_constructor:
+                        type: LIST
+                        elements:
+                          - type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[b]
+                          - type: VALUE_EXPRESSION
+                            value_expression:
+                              type: NUMERIC_EXPRESSION
+                              numeric_expression:
+                                term:
+                                  left:
+                                    factor:
+                                      primary:
+                                        type: VALUE
+                                        value: column-reference[a]
 # Single-value row value constructor lists are OK too
 >SELECT * FROM t1 WHERE (a) = (b)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: (column-reference[a])
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: (column-reference[b])
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: (column-reference[a])
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: (column-reference[b])
 # scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: scalar-subquery[
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
 # scalar subquery inside another scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2 WHERE b = (SELECT c FROM t3))
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[a]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: scalar-subquery[
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2 where[column-reference[b] = scalar-subquery[
 query[selected-columns[column-reference[c]] table-expression[referenced-tables[t3]]]]]]]
 # scalar subquery with correlation and alias
 >SELECT * FROM t1 WHERE num_t2 = (SELECT COUNT(*) FROM t2 WHERE t2.t1_id = t1.id)
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
-      where:
-        search_condition:
-          terms:
-            - factor:
-                predicate:
-                  type: COMPARISON
-                  op: EQUAL
-                  left:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: column-reference[num_t2]
-                  right:
-                    row_value_constructor:
-                      type: ELEMENT
-                      element:
-                        type: VALUE_EXPRESSION
-                        value_expression:
-                          type: NUMERIC_EXPRESSION
-                          numeric_expression:
-                            term:
-                              left:
-                                factor:
-                                  primary:
-                                    type: VALUE
-                                    value: scalar-subquery[
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: COMPARISON
+                    op: EQUAL
+                    left:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[num_t2]
+                    right:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: scalar-subquery[
 query[selected-columns[COUNT(*)] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]]

--- a/tests/grammar/ansi-92/string-expressions.test
+++ b/tests/grammar/ansi-92/string-expressions.test
@@ -2,346 +2,362 @@
 >SELECT 'a' FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal['a']
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: literal['a']
+        referenced_tables:
+          - t1
 # national character string literal value expression primary
 >SELECT N'motorček' FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal['motorček']
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: literal['motorček']
+        referenced_tables:
+          - t1
 # bit string literal value expression primary
 >SELECT B'01000101101' FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal['01000101101']
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: literal['01000101101']
+        referenced_tables:
+          - t1
 # hex string literal value expression primary
 >SELECT X'FE1CD34A' FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: literal['FE1CD34A']
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: literal['FE1CD34A']
+        referenced_tables:
+          - t1
 # A simple scalar subquery
 >SELECT (SELECT b FROM t2) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: scalar-subquery[
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
-      referenced_tables:
-        - t1
+        referenced_tables:
+          - t1
 # named and dynamic parameters
 >SELECT :name, :name_long, ? FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: parameter[name]
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: parameter[name_long]
-        - derived_column:
-            value_expression:
-              type: NUMERIC_EXPRESSION
-              numeric_expression:
-                term:
-                  left:
-                    factor:
-                      primary:
-                        type: VALUE
-                        value: parameter[?]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: parameter[name]
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: parameter[name_long]
+          - derived_column:
+              value_expression:
+                type: NUMERIC_EXPRESSION
+                numeric_expression:
+                  term:
+                    left:
+                      factor:
+                        primary:
+                          type: VALUE
+                          value: parameter[?]
+        referenced_tables:
+          - t1
 # character value expression using collation
 >SELECT 'ß' COLLATE utf8mb4_general_ci FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      value: literal['ß']
-                    collation: utf8mb4_general_ci
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        value: literal['ß']
+                      collation: utf8mb4_general_ci
+        referenced_tables:
+          - t1
 # character value expression using concatenation
 >SELECT a || b FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      value: column-reference[a]
-                  - primary:
-                      value: column-reference[b]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        value: column-reference[a]
+                    - primary:
+                        value: column-reference[b]
+        referenced_tables:
+          - t1
 # character value expression using concatenation with some factors having a collation
 >SELECT a || b COLLATE utf8_bin FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      value: column-reference[a]
-                  - primary:
-                      value: column-reference[b]
-                    collation: utf8_bin
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        value: column-reference[a]
+                    - primary:
+                        value: column-reference[b]
+                      collation: utf8_bin
+        referenced_tables:
+          - t1
 # SUBSTRING string function with no for length modifier
 >SELECT SUBSTRING(a FROM 1) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      function:
-                        type: SUBSTRING
-                        operand:
-                          character_expression:
-                            factors:
-                              - primary:
-                                  value: column-reference[a]
-                        from: literal[1]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        function:
+                          type: SUBSTRING
+                          operand:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: column-reference[a]
+                          from: literal[1]
+        referenced_tables:
+          - t1
 # SUBSTRING string function with a for length modifier
 >SELECT SUBSTRING(a FROM 1 FOR 2) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      function:
-                        type: SUBSTRING
-                        operand:
-                          character_expression:
-                            factors:
-                              - primary:
-                                  value: column-reference[a]
-                        from: literal[1]
-                        for: literal[2]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        function:
+                          type: SUBSTRING
+                          operand:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: column-reference[a]
+                          from: literal[1]
+                          for: literal[2]
+        referenced_tables:
+          - t1
 # UPPER and LOWER string functions
 >SELECT UPPER(a), LOWER(a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      function:
-                        type: UPPER
-                        operand:
-                          character_expression:
-                            factors:
-                              - primary:
-                                  value: column-reference[a]
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      function:
-                        type: LOWER
-                        operand:
-                          character_expression:
-                            factors:
-                              - primary:
-                                  value: column-reference[a]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        function:
+                          type: UPPER
+                          operand:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: column-reference[a]
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        function:
+                          type: LOWER
+                          operand:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: column-reference[a]
+        referenced_tables:
+          - t1
 # TRANSLATE string function
 >SELECT TRANSLATE(a USING utf8_bin) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      function:
-                        type: TRANSLATE
-                        operand:
-                          character_expression:
-                            factors:
-                              - primary:
-                                  value: column-reference[a]
-                        using: utf8_bin
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        function:
+                          type: TRANSLATE
+                          operand:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: column-reference[a]
+                          using: utf8_bin
+        referenced_tables:
+          - t1
 # CONVERT string function
 >SELECT CONVERT(a USING utf8_bin) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      function:
-                        type: CONVERT
-                        operand:
-                          character_expression:
-                            factors:
-                              - primary:
-                                  value: column-reference[a]
-                        using: utf8_bin
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        function:
+                          type: CONVERT
+                          operand:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: column-reference[a]
+                          using: utf8_bin
+        referenced_tables:
+          - t1
 # TRIM string function with no trim specification or character
 >SELECT TRIM(a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      function:
-                        type: TRIM
-                        operand:
-                          character_expression:
-                            factors:
-                              - primary:
-                                  value: column-reference[a]
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        function:
+                          type: TRIM
+                          operand:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: column-reference[a]
+        referenced_tables:
+          - t1
 # TRIM string function with trim specifications
 >SELECT TRIM(LEADING ' ' FROM a) FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            value_expression:
-              type: STRING_EXPRESSION
-              character_expression:
-                factors:
-                  - primary:
-                      function:
-                        type: TRIM
-                        operand:
-                          character_expression:
-                            factors:
-                              - primary:
-                                  value: column-reference[a]
-                        specification: LEADING
-                        character: literal[' ']
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              value_expression:
+                type: STRING_EXPRESSION
+                character_expression:
+                  factors:
+                    - primary:
+                        function:
+                          type: TRIM
+                          operand:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: column-reference[a]
+                          specification: LEADING
+                          character: literal[' ']
+        referenced_tables:
+          - t1

--- a/tests/grammar/ansi-92/string-expressions.test
+++ b/tests/grammar/ansi-92/string-expressions.test
@@ -138,7 +138,7 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: literal['ß']
+                  - primary: literal['ß']
                     collation: utf8mb4_general_ci
       referenced_tables:
         - t1
@@ -153,8 +153,8 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: column-reference[a]
-                  - value: column-reference[b]
+                  - primary: column-reference[a]
+                  - primary: column-reference[b]
       referenced_tables:
         - t1
 # character value expression using concatenation with some factors having a collation
@@ -168,8 +168,8 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: column-reference[a]
-                  - value: column-reference[b]
+                  - primary: column-reference[a]
+                  - primary: column-reference[b]
                     collation: utf8_bin
       referenced_tables:
         - t1
@@ -184,7 +184,7 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: substring[column-reference[a] FROM literal[1]]
+                  - primary: substring[column-reference[a] FROM literal[1]]
       referenced_tables:
         - t1
 # SUBSTRING string function with a for length modifier
@@ -198,7 +198,7 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: substring[column-reference[a] FROM literal[1] FOR literal[2]]
+                  - primary: substring[column-reference[a] FROM literal[1] FOR literal[2]]
       referenced_tables:
         - t1
 # UPPER and LOWER string functions
@@ -212,13 +212,13 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: upper[column-reference[a]]
+                  - primary: upper[column-reference[a]]
         - derived_column:
             value_expression:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: lower[column-reference[a]]
+                  - primary: lower[column-reference[a]]
       referenced_tables:
         - t1
 # TRANSLATE string function
@@ -232,7 +232,7 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: translate[column-reference[a] USING utf8_bin]
+                  - primary: translate[column-reference[a] USING utf8_bin]
       referenced_tables:
         - t1
 # CONVERT string function
@@ -246,7 +246,7 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: convert[column-reference[a] USING utf8_bin]
+                  - primary: convert[column-reference[a] USING utf8_bin]
       referenced_tables:
         - t1
 # TRIM string function with no trim specification or character
@@ -260,7 +260,7 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: trim[column-reference[a]]
+                  - primary: trim[column-reference[a]]
       referenced_tables:
         - t1
 # TRIM string function with trim specifications
@@ -274,6 +274,6 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - value: trim[LEADING literal[' '] FROM column-reference[a]]
+                  - primary: trim[LEADING literal[' '] FROM column-reference[a]]
       referenced_tables:
         - t1

--- a/tests/grammar/ansi-92/string-expressions.test
+++ b/tests/grammar/ansi-92/string-expressions.test
@@ -138,7 +138,8 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: literal['ß']
+                  - primary:
+                      value: literal['ß']
                     collation: utf8mb4_general_ci
       referenced_tables:
         - t1
@@ -153,8 +154,10 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: column-reference[a]
-                  - primary: column-reference[b]
+                  - primary:
+                      value: column-reference[a]
+                  - primary:
+                      value: column-reference[b]
       referenced_tables:
         - t1
 # character value expression using concatenation with some factors having a collation
@@ -168,8 +171,10 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: column-reference[a]
-                  - primary: column-reference[b]
+                  - primary:
+                      value: column-reference[a]
+                  - primary:
+                      value: column-reference[b]
                     collation: utf8_bin
       referenced_tables:
         - t1
@@ -184,7 +189,15 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: substring[column-reference[a] FROM literal[1]]
+                  - primary:
+                      function:
+                        type: SUBSTRING
+                        operand:
+                          character_expression:
+                            factors:
+                              - primary:
+                                  value: column-reference[a]
+                        from: literal[1]
       referenced_tables:
         - t1
 # SUBSTRING string function with a for length modifier
@@ -198,7 +211,16 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: substring[column-reference[a] FROM literal[1] FOR literal[2]]
+                  - primary:
+                      function:
+                        type: SUBSTRING
+                        operand:
+                          character_expression:
+                            factors:
+                              - primary:
+                                  value: column-reference[a]
+                        from: literal[1]
+                        for: literal[2]
       referenced_tables:
         - t1
 # UPPER and LOWER string functions
@@ -212,13 +234,27 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: upper[column-reference[a]]
+                  - primary:
+                      function:
+                        type: UPPER
+                        operand:
+                          character_expression:
+                            factors:
+                              - primary:
+                                  value: column-reference[a]
         - derived_column:
             value_expression:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: lower[column-reference[a]]
+                  - primary:
+                      function:
+                        type: LOWER
+                        operand:
+                          character_expression:
+                            factors:
+                              - primary:
+                                  value: column-reference[a]
       referenced_tables:
         - t1
 # TRANSLATE string function
@@ -232,7 +268,15 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: translate[column-reference[a] USING utf8_bin]
+                  - primary:
+                      function:
+                        type: TRANSLATE
+                        operand:
+                          character_expression:
+                            factors:
+                              - primary:
+                                  value: column-reference[a]
+                        using: utf8_bin
       referenced_tables:
         - t1
 # CONVERT string function
@@ -246,7 +290,15 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: convert[column-reference[a] USING utf8_bin]
+                  - primary:
+                      function:
+                        type: CONVERT
+                        operand:
+                          character_expression:
+                            factors:
+                              - primary:
+                                  value: column-reference[a]
+                        using: utf8_bin
       referenced_tables:
         - t1
 # TRIM string function with no trim specification or character
@@ -260,7 +312,14 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: trim[column-reference[a]]
+                  - primary:
+                      function:
+                        type: TRIM
+                        operand:
+                          character_expression:
+                            factors:
+                              - primary:
+                                  value: column-reference[a]
       referenced_tables:
         - t1
 # TRIM string function with trim specifications
@@ -274,6 +333,15 @@ statements:
               type: STRING_EXPRESSION
               character_expression:
                 factors:
-                  - primary: trim[LEADING literal[' '] FROM column-reference[a]]
+                  - primary:
+                      function:
+                        type: TRIM
+                        operand:
+                          character_expression:
+                            factors:
+                              - primary:
+                                  value: column-reference[a]
+                        specification: LEADING
+                        character: literal[' ']
       referenced_tables:
         - t1

--- a/tests/grammar/ansi-92/table-references.test
+++ b/tests/grammar/ansi-92/table-references.test
@@ -2,39 +2,43 @@
 >SELECT * FROM t1
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
 # Normal table with an alias using AS keyword
 >SELECT * FROM t1 AS t1_alias
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1 AS t1_alias
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1 AS t1_alias
 # Normal table with an alias NOT using AS keyword
 >SELECT * FROM t1 t1_alias
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - t1 AS t1_alias
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1 AS t1_alias
 # Derived table with name using AS keyword
 >SELECT * FROM (SELECT a, b FROM t1) AS t
 statements:
   - type: SELECT
-    query:
-      selected_columns:
-        - derived_column:
-            asterisk: true
-      referenced_tables:
-        - <derived table> AS t
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - <derived table> AS t

--- a/tests/grammar/ansi-92/update.test
+++ b/tests/grammar/ansi-92/update.test
@@ -2,48 +2,50 @@
 >UPDATE t1 SET a = 1
 statements:
   - type: UPDATE
-    table_name: t1
-    set_columns:
-      a: literal[1]
+    update_statement:
+      table_name: t1
+      set_columns:
+        a: literal[1]
 # UPDATE with simple WHERE condition with equality comparison
 >UPDATE t1 SET a = 1 WHERE b = 2
 statements:
   - type: UPDATE
-    table_name: t1
-    set_columns:
-      a: literal[1]
-    where:
-      search_condition:
-        terms:
-          - factor:
-              predicate:
-                type: COMPARISON
-                op: EQUAL
-                left:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: column-reference[b]
-                right:
-                  row_value_constructor:
-                    type: ELEMENT
-                    element:
-                      type: VALUE_EXPRESSION
-                      value_expression:
-                        type: NUMERIC_EXPRESSION
-                        numeric_expression:
-                          term:
-                            left:
-                              factor:
-                                primary:
-                                  type: VALUE
-                                  value: literal[2]
+    update_statement:
+      table_name: t1
+      set_columns:
+        a: literal[1]
+      where:
+        search_condition:
+          terms:
+            - factor:
+                predicate:
+                  type: COMPARISON
+                  op: EQUAL
+                  left:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: column-reference[b]
+                  right:
+                    row_value_constructor:
+                      type: ELEMENT
+                      element:
+                        type: VALUE_EXPRESSION
+                        value_expression:
+                          type: NUMERIC_EXPRESSION
+                          numeric_expression:
+                            term:
+                              left:
+                                factor:
+                                  primary:
+                                    type: VALUE
+                                    value: literal[2]


### PR DESCRIPTION
- Indents all statement classes under a top-level label that matches the statement type
- breaks out string function and numeric function YAML printers

Issue #104 