### PR TITLE
YAML printers for various factors, functions and table_reference_t

### DIFF
--- a/libsqltoast/include/sqltoast/value.h
+++ b/libsqltoast/include/sqltoast/value.h
@@ -564,10 +564,12 @@ typedef struct interval_primary {
 
 typedef struct interval_factor {
     int8_t sign;
-    std::unique_ptr<interval_primary_t> value;
-    interval_factor(int8_t sign, std::unique_ptr<interval_primary_t>& value) :
+    std::unique_ptr<interval_primary_t> primary;
+    interval_factor(
+            int8_t sign,
+            std::unique_ptr<interval_primary_t>& primary) :
         sign(sign),
-        value(std::move(value))
+        primary(std::move(primary))
     {}
 } interval_factor_t;
 

--- a/libsqltoast/include/sqltoast/value.h
+++ b/libsqltoast/include/sqltoast/value.h
@@ -496,12 +496,12 @@ typedef struct current_datetime_function : datetime_function_t {
 // A datetime factor evaluates to a datetime value. It contains a datetime
 // primary and has an optional timezone component.
 typedef struct datetime_factor {
-    std::unique_ptr<datetime_primary_t> value;
+    std::unique_ptr<datetime_primary_t> primary;
     lexeme_t tz;
     datetime_factor(
-            std::unique_ptr<datetime_primary_t>& value,
+            std::unique_ptr<datetime_primary_t>& primary,
             lexeme_t tz) :
-        value(std::move(value)),
+        primary(std::move(primary)),
         tz(tz)
     {}
     inline bool is_local_tz() const {

--- a/libsqltoast/src/parser/symbol.h
+++ b/libsqltoast/src/parser/symbol.h
@@ -225,6 +225,7 @@ inline bool is_value_expression_terminator(const symbol_t& sym) {
         case SYMBOL_AND:
         case SYMBOL_COMMA:
         case SYMBOL_ELSE:
+        case SYMBOL_ESCAPE:
         case SYMBOL_END:
         case SYMBOL_EOS:
         case SYMBOL_EQUAL:

--- a/libsqltoast/src/print/table_reference.cc
+++ b/libsqltoast/src/print/table_reference.cc
@@ -30,8 +30,6 @@ std::ostream& operator<< (std::ostream& out, const table_reference_t& tr) {
                 out << jt;
             }
             break;
-        default:
-            break;
     }
     return out;
 }

--- a/libsqltoast/src/print/value.cc
+++ b/libsqltoast/src/print/value.cc
@@ -456,7 +456,7 @@ std::ostream& operator<< (std::ostream& out, const datetime_primary_t& dp) {
 }
 
 std::ostream& operator<< (std::ostream& out, const datetime_factor_t& factor) {
-    out << *factor.value;
+    out << *factor.primary;
     if (factor.is_local_tz())
         out << " AT LOCAL";
     else

--- a/libsqltoast/src/print/value.cc
+++ b/libsqltoast/src/print/value.cc
@@ -505,7 +505,7 @@ std::ostream& operator<< (std::ostream& out, const interval_primary_t& primary) 
 std::ostream& operator<< (std::ostream& out, const interval_factor_t& factor) {
     if (factor.sign != 0)
         out << factor.sign << ' ';
-    out << *factor.value;
+    out << *factor.primary;
     return out;
 }
 

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -828,7 +828,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::like_predicate_t
     ptr.indent_pop(out);
     if (pred.escape_char) {
         const sqltoast::character_value_expression_t& escape_char_val =
-            static_cast<const sqltoast::character_value_expression_t&>(*pred.pattern);
+            static_cast<const sqltoast::character_value_expression_t&>(*pred.escape_char);
         ptr.indent(out) << "escape:";
         ptr.indent_push(out);
         to_yaml(ptr, out, escape_char_val);

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -1431,7 +1431,34 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_factor_
         ptr.indent(out) << "time_zone: LOCAL";
     else
         ptr.indent(out) << "time_zone: " << factor.tz;
-    ptr.indent(out) << "primary: " << *factor.primary;
+    to_yaml(ptr, out, *factor.primary);
+    ptr.indent_pop(out);
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_primary_t& primary) {
+    ptr.indent(out) << "primary:";
+    ptr.indent_push(out);
+    ptr.indent(out) << "type: ";
+    switch (primary.type) {
+        case sqltoast::DATETIME_PRIMARY_TYPE_VALUE:
+            out << "VALUE";
+            ptr.indent(out) << "value: ";
+            {
+                const sqltoast::datetime_value_t& sub =
+                    static_cast<const sqltoast::datetime_value_t&>(primary);
+                out << sub;
+            }
+            break;
+        case sqltoast::DATETIME_PRIMARY_TYPE_FUNCTION:
+            out << "FUNCTION";
+            ptr.indent(out) << "function: ";
+            {
+                const sqltoast::current_datetime_function_t& sub =
+                    static_cast<const sqltoast::current_datetime_function_t&>(primary);
+                out << sub;
+            }
+            break;
+    }
     ptr.indent_pop(out);
 }
 

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -1404,7 +1404,12 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::trim_function_t&
                 out << "BOTH";
                 break;
         }
-        ptr.indent(out) << "character: " << *func.trim_character;
+        ptr.indent(out) << "trim_character:";
+        ptr.indent_push(out);
+        const sqltoast::character_value_expression_t& trim_char_val =
+            static_cast<sqltoast::character_value_expression_t&>(*func.trim_character);
+        to_yaml(ptr, out, trim_char_val);
+        ptr.indent_pop(out);
     }
 }
 

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -822,10 +822,18 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::like_predicate_t
         ptr.indent(out) << "negate: true";
     ptr.indent(out) << "pattern:";
     ptr.indent_push(out);
-    to_yaml(ptr, out, *pred.pattern);
+    const sqltoast::character_value_expression_t& pattern_val =
+        static_cast<const sqltoast::character_value_expression_t&>(*pred.pattern);
+    to_yaml(ptr, out, pattern_val);
     ptr.indent_pop(out);
-    if (pred.escape_char)
-        ptr.indent(out) << "escape_char: " << *pred.escape_char;
+    if (pred.escape_char) {
+        const sqltoast::character_value_expression_t& escape_char_val =
+            static_cast<const sqltoast::character_value_expression_t&>(*pred.pattern);
+        ptr.indent(out) << "escape:";
+        ptr.indent_push(out);
+        to_yaml(ptr, out, escape_char_val);
+        ptr.indent_pop(out);
+    }
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::null_predicate_t& pred) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -1480,7 +1480,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_factor_
     ptr.indent_push(out);
     if (factor.sign != 0)
         ptr.indent(out) << "sign: " << factor.sign;
-    ptr.indent(out) << "primary: " << *factor.value;
+    ptr.indent(out) << "primary: " << *factor.primary;
     ptr.indent_pop(out);
 }
 

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -1366,9 +1366,20 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::string_function_
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::substring_function_t& func) {
-    ptr.indent(out) << "from: " << *func.start_position_value;
-    if (func.for_length_value)
-        ptr.indent(out) << "for: " << *func.for_length_value;
+    ptr.indent(out) << "start_position:";
+    ptr.indent_push(out);
+    const sqltoast::numeric_expression_t& start_pos_val =
+        static_cast<sqltoast::numeric_expression_t&>(*func.start_position_value);
+    to_yaml(ptr, out, start_pos_val);
+    ptr.indent_pop(out);
+    if (func.for_length_value) {
+        ptr.indent(out) << "for_length:";
+        ptr.indent_push(out);
+        const sqltoast::numeric_expression_t& for_length_val =
+            static_cast<sqltoast::numeric_expression_t&>(*func.for_length_value);
+        to_yaml(ptr, out, for_length_val);
+        ptr.indent_pop(out);
+    }
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::convert_function_t& func) {

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -1431,7 +1431,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_factor_
         ptr.indent(out) << "time_zone: LOCAL";
     else
         ptr.indent(out) << "time_zone: " << factor.tz;
-    ptr.indent(out) << "value: " << *factor.value;
+    ptr.indent(out) << "primary: " << *factor.primary;
     ptr.indent_pop(out);
 }
 

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -34,6 +34,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_table_sta
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_view_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_factor_t& factor);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_field_t& field);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_primary_t& primary);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_term_t& term);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_value_expression_t& de);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::delete_statement_t& stmt);

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -87,6 +87,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::statement_t& stm
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::string_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::substring_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_expression_t& table_exp);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_reference_t& tr);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::translate_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::trim_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::unique_predicate_t& pred);

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -33,6 +33,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_schema_st
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_table_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::create_view_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_factor_t& factor);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_field_t& field);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_term_t& term);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::datetime_value_expression_t& de);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::delete_statement_t& stmt);
@@ -51,6 +52,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_values_predic
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_select_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_factor_t& factor);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_primary_t& primary);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_qualifier_t& qualifier);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_term_t& term);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_value_expression_t& ie);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::joined_table_query_expression_t& qe);

--- a/tests/grammar/ansi-92/case-expressions.test
+++ b/tests/grammar/ansi-92/case-expressions.test
@@ -28,7 +28,8 @@ statements:
                           type: VALUE
                           value: coalesce[column-reference[a],literal['n/a']]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # COALESCE with 4 args
 >SELECT COALESCE(a, b, c, 'n/a') FROM t1
 statements:
@@ -47,7 +48,8 @@ statements:
                           type: VALUE
                           value: coalesce[column-reference[a],column-reference[b],column-reference[c],literal['n/a']]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # NULLIF with 2 args
 >SELECT NULLIF(a, 'n/a') FROM t1
 statements:
@@ -66,7 +68,8 @@ statements:
                           type: VALUE
                           value: nullif[column-reference[a],literal['n/a']]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple CASE expression single WHEN no ELSE
 >SELECT CASE a WHEN 1 THEN 2 END FROM t1
 statements:
@@ -85,7 +88,8 @@ statements:
                           type: VALUE
                           value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple CASE expression multiple WHEN no ELSE
 >SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 END FROM t1
 statements:
@@ -104,7 +108,8 @@ statements:
                           type: VALUE
                           value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple CASE expression single WHEN with ELSE
 >SELECT CASE a WHEN 1 THEN 2 ELSE 42 END FROM t1
 statements:
@@ -123,7 +128,8 @@ statements:
                           type: VALUE
                           value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] ELSE literal[42]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple CASE expression multiple WHEN with ELSE
 >SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t1
 statements:
@@ -142,7 +148,8 @@ statements:
                           type: VALUE
                           value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3] ELSE literal[4]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Searched CASE expression single WHEN no ELSE
 >SELECT CASE WHEN a = 1 THEN 2 END FROM t1
 statements:
@@ -161,7 +168,8 @@ statements:
                           type: VALUE
                           value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Searched CASE expression multiple WHEN no ELSE
 >SELECT CASE WHEN a = 1 THEN 2 WHEN a = 2 THEN 3 END FROM t1
 statements:
@@ -180,7 +188,8 @@ statements:
                           type: VALUE
                           value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Searched CASE expression single WHEN with ELSE
 >SELECT CASE WHEN a = 1 THEN 2 ELSE 42 END FROM t1
 statements:
@@ -199,7 +208,8 @@ statements:
                           type: VALUE
                           value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] ELSE literal[42]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Searched CASE expression multiple WHEN with ELSE
 >SELECT CASE WHEN a = 1 THEN 2 WHEN a = 2 THEN 3 ELSE 4 END FROM t1
 statements:
@@ -218,4 +228,5 @@ statements:
                           type: VALUE
                           value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3] ELSE literal[4]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1

--- a/tests/grammar/ansi-92/create-view.test
+++ b/tests/grammar/ansi-92/create-view.test
@@ -20,7 +20,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Use the optional column list
 >CREATE VIEW v1 (a, b) AS SELECT a, b FROM t1
 statements:
@@ -53,7 +54,8 @@ statements:
                           type: VALUE
                           value: column-reference[b]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # The optional WITH LOCAL CHECK OPTION clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH LOCAL CHECK OPTION
 statements:
@@ -66,7 +68,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # The optional WITH CASCADED CHECK OPTION clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH CASCADED CHECK OPTION
 statements:
@@ -79,7 +82,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Missing either LOCAL or CASCADED for the check option clause
 >CREATE VIEW v1 AS SELECT * FROM t1 WITH CHECK OPTION
 Syntax error.

--- a/tests/grammar/ansi-92/datetime-expressions.test
+++ b/tests/grammar/ansi-92/datetime-expressions.test
@@ -17,7 +17,8 @@ statements:
                           type: VALUE
                           value: column-reference[a]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple datetime expression with specifier timezone
 >SELECT a AT TIME ZONE 'UTC' FROM t1
 statements:
@@ -37,7 +38,8 @@ statements:
                           type: VALUE
                           value: column-reference[a]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # CURRENT_DATE datetime function
 >SELECT CURRENT_DATE FROM t1
 statements:
@@ -57,7 +59,8 @@ statements:
                           type: FUNCTION
                           function: current-date[]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # CURRENT_DATE datetime function with timezone component
 >SELECT CURRENT_DATE AT TIME ZONE 'UTC' FROM t1
 statements:
@@ -77,7 +80,8 @@ statements:
                           type: FUNCTION
                           function: current-date[]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # CURRENT_TIME datetime function with no time precision
 >SELECT CURRENT_TIME FROM t1
 statements:
@@ -97,7 +101,8 @@ statements:
                           type: FUNCTION
                           function: current-time[]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # CURRENT_TIME datetime function with fractional time precision
 >SELECT CURRENT_TIME(3) FROM t1
 statements:
@@ -117,7 +122,8 @@ statements:
                           type: FUNCTION
                           function: current-time[3]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # CURRENT_TIMESTAMP datetime function with no time precision
 >SELECT CURRENT_TIMESTAMP FROM t1
 statements:
@@ -137,7 +143,8 @@ statements:
                           type: FUNCTION
                           function: current-timestamp[]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # CURRENT_TIMESTAMP datetime function with fractional time precision
 >SELECT CURRENT_TIMESTAMP(3) FROM t1
 statements:
@@ -157,7 +164,8 @@ statements:
                           type: FUNCTION
                           function: current-timestamp[3]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Add a datetime term to an interval term
 >SELECT a AT LOCAL + b YEAR TO MONTH FROM t1
 statements:
@@ -189,7 +197,8 @@ statements:
                               end:
                                 interval: MONTH
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Subtract an interval term from a datetime expression
 >SELECT a AT LOCAL - b DAY FROM t1
 statements:
@@ -219,4 +228,5 @@ statements:
                               start:
                                 interval: DAY
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1

--- a/tests/grammar/ansi-92/datetime-expressions.test
+++ b/tests/grammar/ansi-92/datetime-expressions.test
@@ -163,7 +163,13 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[b] YEAR TO MONTH
+                          primary:
+                            value: column-reference[b]
+                            qualifier:
+                              start:
+                                interval: YEAR
+                              end:
+                                interval: MONTH
         referenced_tables:
           - t1
 # Subtract an interval term from a datetime expression
@@ -187,6 +193,10 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[b] DAY
+                          primary:
+                            value: column-reference[b]
+                            qualifier:
+                              start:
+                                interval: DAY
         referenced_tables:
           - t1

--- a/tests/grammar/ansi-92/datetime-expressions.test
+++ b/tests/grammar/ansi-92/datetime-expressions.test
@@ -13,7 +13,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: column-reference[a]
+                        primary:
+                          type: VALUE
+                          value: column-reference[a]
         referenced_tables:
           - t1
 # Simple datetime expression with specifier timezone
@@ -31,7 +33,9 @@ statements:
                     term:
                       factor:
                         time_zone: 'UTC'
-                        primary: column-reference[a]
+                        primary:
+                          type: VALUE
+                          value: column-reference[a]
         referenced_tables:
           - t1
 # CURRENT_DATE datetime function
@@ -49,7 +53,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: current-date[]
+                        primary:
+                          type: FUNCTION
+                          function: current-date[]
         referenced_tables:
           - t1
 # CURRENT_DATE datetime function with timezone component
@@ -67,7 +73,9 @@ statements:
                     term:
                       factor:
                         time_zone: 'UTC'
-                        primary: current-date[]
+                        primary:
+                          type: FUNCTION
+                          function: current-date[]
         referenced_tables:
           - t1
 # CURRENT_TIME datetime function with no time precision
@@ -85,7 +93,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: current-time[]
+                        primary:
+                          type: FUNCTION
+                          function: current-time[]
         referenced_tables:
           - t1
 # CURRENT_TIME datetime function with fractional time precision
@@ -103,7 +113,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: current-time[3]
+                        primary:
+                          type: FUNCTION
+                          function: current-time[3]
         referenced_tables:
           - t1
 # CURRENT_TIMESTAMP datetime function with no time precision
@@ -121,7 +133,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: current-timestamp[]
+                        primary:
+                          type: FUNCTION
+                          function: current-timestamp[]
         referenced_tables:
           - t1
 # CURRENT_TIMESTAMP datetime function with fractional time precision
@@ -139,7 +153,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: current-timestamp[3]
+                        primary:
+                          type: FUNCTION
+                          function: current-timestamp[3]
         referenced_tables:
           - t1
 # Add a datetime term to an interval term
@@ -157,7 +173,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: column-reference[a]
+                        primary:
+                          type: VALUE
+                          value: column-reference[a]
                   op: ADD
                   right:
                     term:
@@ -187,7 +205,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: column-reference[a]
+                        primary:
+                          type: VALUE
+                          value: column-reference[a]
                   op: SUBTRACT
                   right:
                     term:

--- a/tests/grammar/ansi-92/datetime-expressions.test
+++ b/tests/grammar/ansi-92/datetime-expressions.test
@@ -13,7 +13,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: column-reference[a]
+                        primary: column-reference[a]
         referenced_tables:
           - t1
 # Simple datetime expression with specifier timezone
@@ -31,7 +31,7 @@ statements:
                     term:
                       factor:
                         time_zone: 'UTC'
-                        value: column-reference[a]
+                        primary: column-reference[a]
         referenced_tables:
           - t1
 # CURRENT_DATE datetime function
@@ -49,7 +49,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: current-date[]
+                        primary: current-date[]
         referenced_tables:
           - t1
 # CURRENT_DATE datetime function with timezone component
@@ -67,7 +67,7 @@ statements:
                     term:
                       factor:
                         time_zone: 'UTC'
-                        value: current-date[]
+                        primary: current-date[]
         referenced_tables:
           - t1
 # CURRENT_TIME datetime function with no time precision
@@ -85,7 +85,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: current-time[]
+                        primary: current-time[]
         referenced_tables:
           - t1
 # CURRENT_TIME datetime function with fractional time precision
@@ -103,7 +103,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: current-time[3]
+                        primary: current-time[3]
         referenced_tables:
           - t1
 # CURRENT_TIMESTAMP datetime function with no time precision
@@ -121,7 +121,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: current-timestamp[]
+                        primary: current-timestamp[]
         referenced_tables:
           - t1
 # CURRENT_TIMESTAMP datetime function with fractional time precision
@@ -139,7 +139,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: current-timestamp[3]
+                        primary: current-timestamp[3]
         referenced_tables:
           - t1
 # Add a datetime term to an interval term
@@ -157,7 +157,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: column-reference[a]
+                        primary: column-reference[a]
                   op: ADD
                   right:
                     term:
@@ -187,7 +187,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: column-reference[a]
+                        primary: column-reference[a]
                   op: SUBTRACT
                   right:
                     term:

--- a/tests/grammar/ansi-92/identifiers.test
+++ b/tests/grammar/ansi-92/identifiers.test
@@ -8,7 +8,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Identifier includes an underscore
 >SELECT * FROM t1_backup
 statements:
@@ -19,7 +20,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1_backup
+          - type: TABLE
+            table: t1_backup
 # Identifier includes a period
 >SELECT * FROM s1.t1
 statements:
@@ -30,7 +32,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - s1.t1
+          - type: TABLE
+            table: s1.t1
 # Identifier includes multiple periods and underscore
 >SELECT * FROM c1.s1.t1_backup
 statements:
@@ -41,7 +44,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - c1.s1.t1_backup
+          - type: TABLE
+            table: c1.s1.t1_backup
 # Identifier includes a prefix and a star projection
 >SELECT t1.* FROM t1
 statements:
@@ -60,4 +64,5 @@ statements:
                           type: VALUE
                           value: column-reference[t1.*]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1

--- a/tests/grammar/ansi-92/insert-select.test
+++ b/tests/grammar/ansi-92/insert-select.test
@@ -28,7 +28,8 @@ statements:
                           type: VALUE
                           value: column-reference[b]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # INSERT SELECT with target columns and a search condition
 >INSERT INTO t1 (t1_a, t1_b) SELECT a, b FROM t1 WHERE c < 3
 statements:
@@ -61,7 +62,8 @@ statements:
                           type: VALUE
                           value: column-reference[b]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -107,7 +107,7 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        value: current-date[]
+                        primary: current-date[]
         - row_value_constructor:
             type: ELEMENT
             element:
@@ -119,7 +119,7 @@ statements:
                     term:
                       factor:
                         time_zone: 'UTC'
-                        value: literal['2001-01-01']
+                        primary: literal['2001-01-01']
 # INSERT INTO using interval value expressions
 >INSERT INTO t1 (num_seconds) VALUES ('2001-01-01' DAY TO SECOND)
 statements:

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -140,7 +140,13 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: literal['2001-01-01'] DAY TO SECOND
+                          primary:
+                            value: literal['2001-01-01']
+                            qualifier:
+                              start:
+                                interval: DAY
+                              end:
+                                interval: SECOND
 # INSERT INTO using numeric value expressions
 >INSERT INTO t1 (num_seconds) VALUES (1 + (2 * 3))
 statements:

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -107,7 +107,9 @@ statements:
                     term:
                       factor:
                         time_zone: LOCAL
-                        primary: current-date[]
+                        primary:
+                          type: FUNCTION
+                          function: current-date[]
         - row_value_constructor:
             type: ELEMENT
             element:
@@ -119,7 +121,9 @@ statements:
                     term:
                       factor:
                         time_zone: 'UTC'
-                        primary: literal['2001-01-01']
+                        primary:
+                          type: VALUE
+                          value: literal['2001-01-01']
 # INSERT INTO using interval value expressions
 >INSERT INTO t1 (num_seconds) VALUES ('2001-01-01' DAY TO SECOND)
 statements:

--- a/tests/grammar/ansi-92/interval-expressions.test
+++ b/tests/grammar/ansi-92/interval-expressions.test
@@ -19,7 +19,8 @@ statements:
                               start:
                                 interval: YEAR
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple interval value expression with non-second interval qualifier with a
 # leading precision
 >SELECT a DAY(2) FROM t1
@@ -43,7 +44,8 @@ statements:
                                 interval: DAY
                                 leading_precision: 2
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple interval value expression with second interval qualifier with a
 # leading precision and no fractional precision
 >SELECT a SECOND(2) FROM t1
@@ -67,7 +69,8 @@ statements:
                                 interval: SECOND
                                 leading_precision: 2
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple interval value expression with second interval qualifier with a
 # leading precision and no fractional precision
 >SELECT a SECOND(2, 5) FROM t1
@@ -92,7 +95,8 @@ statements:
                                 leading_precision: 2
                                 fractional_precision: 5
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # interval value expression with start and end non-second interval qualifier
 # with no precision specifiers
 >SELECT a YEAR TO MONTH FROM t1
@@ -117,7 +121,8 @@ statements:
                               end:
                                 interval: MONTH
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # interval value expression with start non-second and end second interval
 # qualifier with no precision specifiers
 >SELECT a DAY TO SECOND FROM t1
@@ -142,7 +147,8 @@ statements:
                               end:
                                 interval: SECOND
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # interval value expression with start non-second and end second interval
 # qualifier with a second fractional precision specifier
 >SELECT a DAY TO SECOND(5) FROM t1
@@ -169,7 +175,8 @@ statements:
                                 leading_precision: 0
                                 fractional_precision: 5
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # interval value expression that operates on an interval term with a numeric
 # factor
 >SELECT a YEAR * 12, a YEAR / 2, a MONTH / (12 / b) FROM t1
@@ -236,7 +243,8 @@ statements:
                             type: VALUE
                             value: (numeric-expression[literal[12] / column-reference[b]])
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # interval value expression that uses addition and subtraction operators on
 # interval terms
 >SELECT a YEAR + 12 YEAR, created_on DAY TO SECOND - updated_on DAY TO SECOND from t1
@@ -296,4 +304,5 @@ statements:
                               end:
                                 interval: SECOND
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1

--- a/tests/grammar/ansi-92/interval-expressions.test
+++ b/tests/grammar/ansi-92/interval-expressions.test
@@ -13,7 +13,11 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] YEAR
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: YEAR
         referenced_tables:
           - t1
 # Simple interval value expression with non-second interval qualifier with a
@@ -32,7 +36,12 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] DAY(2)
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: DAY
+                                leading_precision: 2
         referenced_tables:
           - t1
 # Simple interval value expression with second interval qualifier with a
@@ -51,7 +60,12 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] SECOND(2)
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: SECOND
+                                leading_precision: 2
         referenced_tables:
           - t1
 # Simple interval value expression with second interval qualifier with a
@@ -70,7 +84,13 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] SECOND(2, 5)
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: SECOND
+                                leading_precision: 2
+                                fractional_precision: 5
         referenced_tables:
           - t1
 # interval value expression with start and end non-second interval qualifier
@@ -89,7 +109,13 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] YEAR TO MONTH
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: YEAR
+                              end:
+                                interval: MONTH
         referenced_tables:
           - t1
 # interval value expression with start non-second and end second interval
@@ -108,7 +134,13 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] DAY TO SECOND
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: DAY
+                              end:
+                                interval: SECOND
         referenced_tables:
           - t1
 # interval value expression with start non-second and end second interval
@@ -127,7 +159,15 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] DAY TO SECOND(0, 5)
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: DAY
+                              end:
+                                interval: SECOND
+                                leading_precision: 0
+                                fractional_precision: 5
         referenced_tables:
           - t1
 # interval value expression that operates on an interval term with a numeric
@@ -146,7 +186,11 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] YEAR
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: YEAR
                       op: MULTIPLY
                       right:
                         factor:
@@ -161,7 +205,11 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] YEAR
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: YEAR
                       op: DIVIDE
                       right:
                         factor:
@@ -176,7 +224,11 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] MONTH
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: MONTH
                       op: DIVIDE
                       right:
                         factor:
@@ -201,13 +253,21 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[a] YEAR
+                          primary:
+                            value: column-reference[a]
+                            qualifier:
+                              start:
+                                interval: YEAR
                   op: ADD
                   right:
                     term:
                       left:
                         factor:
-                          primary: literal[12] YEAR
+                          primary:
+                            value: literal[12]
+                            qualifier:
+                              start:
+                                interval: YEAR
           - derived_column:
               value_expression:
                 type: INTERVAL_EXPRESSION
@@ -216,12 +276,24 @@ statements:
                     term:
                       left:
                         factor:
-                          primary: column-reference[created_on] DAY TO SECOND
+                          primary:
+                            value: column-reference[created_on]
+                            qualifier:
+                              start:
+                                interval: DAY
+                              end:
+                                interval: SECOND
                   op: SUBTRACT
                   right:
                     term:
                       left:
                         factor:
-                          primary: column-reference[updated_on] DAY TO SECOND
+                          primary:
+                            value: column-reference[updated_on]
+                            qualifier:
+                              start:
+                                interval: DAY
+                              end:
+                                interval: SECOND
         referenced_tables:
           - t1

--- a/tests/grammar/ansi-92/joins.test
+++ b/tests/grammar/ansi-92/joins.test
@@ -14,7 +14,15 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - cross-join[t1,t2]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: CROSS
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
 # INNER JOIN two normal tables WITHOUT the INNER symbol
 >SELECT * FROM t1 JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -25,7 +33,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: INNER
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,column-reference[t1.id] = column-reference[t2.t1_id]
 # INNER JOIN two normal tables WITH the INNER symbol
 >SELECT * FROM t1 INNER JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -36,7 +53,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - inner-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: INNER
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,column-reference[t1.id] = column-reference[t2.t1_id]
 # INNER JOIN two normal tables with no join condition
 >SELECT * FROM t1 JOIN t2
 statements:
@@ -47,7 +73,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - inner-join[t1,t2]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: INNER
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: 
 # LEFT JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -58,7 +93,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: LEFT
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,column-reference[t1.id] = column-reference[t2.t1_id]
 # LEFT JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -69,7 +113,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - left-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: LEFT
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,column-reference[t1.id] = column-reference[t2.t1_id]
 # RIGHT JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 RIGHT JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -80,7 +133,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: RIGHT
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,column-reference[t1.id] = column-reference[t2.t1_id]
 # RIGHT JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -91,7 +153,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - right-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: RIGHT
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,column-reference[t1.id] = column-reference[t2.t1_id]
 # FULL OUTER JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 FULL JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -102,7 +173,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: FULL
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,column-reference[t1.id] = column-reference[t2.t1_id]
 # FULL OUTER JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -113,7 +193,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - full-join[t1,t2,column-reference[t1.id] = column-reference[t2.t1_id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: FULL
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,column-reference[t1.id] = column-reference[t2.t1_id]
 # JOIN with USING clause
 >SELECT * FROM t1 JOIN t2 USING (id)
 statements:
@@ -124,7 +213,16 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - inner-join[t1,t2,using[id]]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: INNER
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
+              specification: ,using[id]
 # NATURAL JOIN
 >SELECT * FROM t1 NATURAL JOIN t2
 statements:
@@ -135,7 +233,15 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - natural-join[t1,t2]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: NATURAL
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2
 # UNION JOIN of two tables
 >SELECT * FROM t1 UNION JOIN t2
 statements:
@@ -146,4 +252,12 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - union-join[t1,t2]
+          - type: JOINED_TABLE
+            joined_table:
+              join_type: UNION
+              left:
+                type: TABLE
+                  table: t1
+              right:
+                type: TABLE
+                  table: t2

--- a/tests/grammar/ansi-92/numeric-expressions.test
+++ b/tests/grammar/ansi-92/numeric-expressions.test
@@ -16,7 +16,8 @@ statements:
                           type: VALUE
                           value: literal[1]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Simple addition of literal number to column reference
 >UPDATE t1 SET x = 1 WHERE a = (2 + b)
 statements:
@@ -290,7 +291,8 @@ statements:
                           type: VALUE
                           value: VALUE
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # COUNT set function specifications
 >SELECT COUNT(*), COUNT(DISTINCT a), COUNT(a) FROM t1
 statements:
@@ -329,7 +331,8 @@ statements:
                           type: VALUE
                           value: COUNT(column-reference[a])
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # SUM set function specifications
 >SELECT SUM(DISTINCT a), SUM(a) FROM t1
 statements:
@@ -358,7 +361,8 @@ statements:
                           type: VALUE
                           value: SUM(column-reference[a])
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # AVG set function specifications
 >SELECT AVG(DISTINCT a), AVG(a) FROM t1
 statements:
@@ -387,7 +391,8 @@ statements:
                           type: VALUE
                           value: AVG(column-reference[a])
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # MIN set function specifications
 >SELECT MIN(DISTINCT a), MIN(a) FROM t1
 statements:
@@ -416,7 +421,8 @@ statements:
                           type: VALUE
                           value: MIN(column-reference[a])
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # MAX set function specifications
 >SELECT MAX(DISTINCT a), MAX(a) FROM t1
 statements:
@@ -445,7 +451,8 @@ statements:
                           type: VALUE
                           value: MAX(column-reference[a])
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Nested set function specifications
 >SELECT MAX(COUNT(a)) FROM t1
 statements:
@@ -464,7 +471,8 @@ statements:
                           type: VALUE
                           value: MAX(COUNT(column-reference[a]))
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Use of CHAR_LENGTH and CHARACTER_LENGTH numeric functions
 >SELECT CHAR_LENGTH(a), CHARACTER_LENGTH(a) + 1 FROM t1
 statements:
@@ -506,7 +514,8 @@ statements:
                             type: VALUE
                             value: literal[1]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Use of BIT_LENGTH and OCTET_LENGTH numeric functions
 >SELECT BIT_LENGTH(a), OCTET_LENGTH(a) FROM t1
 statements:
@@ -539,7 +548,8 @@ statements:
                             type: OCTET_LENGTH
                             operand: column-reference[a]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Use of EXTRACT numeric function
 >SELECT EXTRACT(YEAR FROM a) FROM t1
 statements:
@@ -561,7 +571,8 @@ statements:
                             field: YEAR
                             source: datetime-expression[column-reference[a] AT LOCAL]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Use of POSITION numeric function
 >SELECT POSITION('123' IN a) FROM t1
 statements:
@@ -583,4 +594,5 @@ statements:
                             find: literal['123']
                             in: column-reference[a]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -1633,12 +1633,10 @@ statements:
                                       type: VALUE
                                       value: column-reference[a]
                     pattern:
-                      value_expression:
-                        type: STRING_EXPRESSION
-                        character_expression:
-                          factors:
-                            - primary:
-                                value: literal['s%']
+                      character_expression:
+                        factors:
+                          - primary:
+                              value: literal['s%']
 # LIKE predicate with concatenated column comparison with string
 >SELECT * FROM t1 WHERE a LIKE b || '%'
 statements:
@@ -1671,14 +1669,12 @@ statements:
                                       type: VALUE
                                       value: column-reference[a]
                     pattern:
-                      value_expression:
-                        type: STRING_EXPRESSION
-                        character_expression:
-                          factors:
-                            - primary:
-                                value: column-reference[b]
-                            - primary:
-                                value: literal['%']
+                      character_expression:
+                        factors:
+                          - primary:
+                              value: column-reference[b]
+                          - primary:
+                              value: literal['%']
 # OVERLAPS predicate with date columns from multiple tables
 >SELECT * FROM t1, t2 WHERE (t1.start, t1.end) OVERLAPS (t2.start, t2.end)
 statements:

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -1637,6 +1637,47 @@ statements:
                         factors:
                           - primary:
                               value: literal['s%']
+# LIKE predicate with simple column comparison with string and escape
+>SELECT * FROM t1 WHERE a LIKE 's%' ESCAPE '"'
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - derived_column:
+              asterisk: true
+        referenced_tables:
+          - t1
+        where:
+          search_condition:
+            terms:
+              - factor:
+                  predicate:
+                    type: LIKE
+                    match:
+                      row_value_constructor:
+                        type: ELEMENT
+                        element:
+                          type: VALUE_EXPRESSION
+                          value_expression:
+                            type: NUMERIC_EXPRESSION
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: column-reference[a]
+                    pattern:
+                      character_expression:
+                        factors:
+                          - primary:
+                              value: literal['s%']
+                    escape:
+                      character_expression:
+                        factors:
+                          - primary:
+                              value: literal['"']
 # LIKE predicate with concatenated column comparison with string
 >SELECT * FROM t1 WHERE a LIKE b || '%'
 statements:

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -8,7 +8,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -54,7 +55,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -100,7 +102,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -146,7 +149,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -225,7 +229,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -303,7 +308,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -415,7 +421,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -527,7 +534,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -641,7 +649,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -823,7 +832,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -864,7 +874,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -906,7 +917,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -948,7 +960,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -991,7 +1004,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1050,7 +1064,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1111,7 +1126,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1145,7 +1161,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t1_a]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
 # EXISTS (<subquery>) predicate
 >SELECT * FROM t1 WHERE EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -1156,7 +1173,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1176,7 +1194,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t1_id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1222,7 +1241,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1242,7 +1262,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t1_id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1289,7 +1310,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1323,7 +1345,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t1_id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1369,7 +1392,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1403,7 +1427,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t1_id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1449,7 +1474,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1484,7 +1510,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t1_id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1530,7 +1557,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1565,7 +1593,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t1_id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1611,7 +1640,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1647,7 +1677,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1688,7 +1719,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1726,8 +1758,10 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
-          - t2
+          - type: TABLE
+            table: t1
+          - type: TABLE
+            table: t2
         where:
           search_condition:
             terms:
@@ -1793,7 +1827,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1813,7 +1848,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t2.id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1859,7 +1895,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1879,7 +1916,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t2.id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1926,7 +1964,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -1946,7 +1985,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t2.id]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
                       where:
                         search_condition:
                           terms:
@@ -1999,7 +2039,8 @@ statements:
                                             type: VALUE
                                             value: column-reference[t3.id]
                           referenced_tables:
-                            - t3
+                            - type: TABLE
+                              table: t3
                           where:
                             search_condition:
                               terms:
@@ -2046,7 +2087,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -2082,7 +2124,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t2.start]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
 # quantified comparison predicate with ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= ANY (SELECT t2.start FROM t2)
 statements:
@@ -2093,7 +2136,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -2129,7 +2173,8 @@ statements:
                                         type: VALUE
                                         value: column-reference[t2.start]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2
 # quantified comparison predicate with SOME quantifier translated to ANY quantifier
 >SELECT * FROM t1 WHERE t1.start <= SOME (SELECT t2.start FROM t2)
 statements:
@@ -2140,7 +2185,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -2176,4 +2222,5 @@ statements:
                                         type: VALUE
                                         value: column-reference[t2.start]
                       referenced_tables:
-                        - t2
+                        - type: TABLE
+                          table: t2

--- a/tests/grammar/ansi-92/row-value-constructors.test
+++ b/tests/grammar/ansi-92/row-value-constructors.test
@@ -9,7 +9,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -75,7 +76,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -121,7 +123,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -168,7 +171,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:
@@ -216,7 +220,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
         where:
           search_condition:
             terms:

--- a/tests/grammar/ansi-92/string-expressions.test
+++ b/tests/grammar/ansi-92/string-expressions.test
@@ -16,7 +16,8 @@ statements:
                           type: VALUE
                           value: literal['a']
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # national character string literal value expression primary
 >SELECT N'motorček' FROM t1
 statements:
@@ -35,7 +36,8 @@ statements:
                           type: VALUE
                           value: literal['motorček']
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # bit string literal value expression primary
 >SELECT B'01000101101' FROM t1
 statements:
@@ -54,7 +56,8 @@ statements:
                           type: VALUE
                           value: literal['01000101101']
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # hex string literal value expression primary
 >SELECT X'FE1CD34A' FROM t1
 statements:
@@ -73,7 +76,8 @@ statements:
                           type: VALUE
                           value: literal['FE1CD34A']
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # A simple scalar subquery
 >SELECT (SELECT b FROM t2) FROM t1
 statements:
@@ -93,7 +97,8 @@ statements:
                           value: scalar-subquery[
 query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # named and dynamic parameters
 >SELECT :name, :name_long, ? FROM t1
 statements:
@@ -132,7 +137,8 @@ statements:
                           type: VALUE
                           value: parameter[?]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # character value expression using collation
 >SELECT 'ß' COLLATE utf8mb4_general_ci FROM t1
 statements:
@@ -149,7 +155,8 @@ statements:
                         value: literal['ß']
                       collation: utf8mb4_general_ci
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # character value expression using concatenation
 >SELECT a || b FROM t1
 statements:
@@ -167,7 +174,8 @@ statements:
                     - primary:
                         value: column-reference[b]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # character value expression using concatenation with some factors having a collation
 >SELECT a || b COLLATE utf8_bin FROM t1
 statements:
@@ -186,7 +194,8 @@ statements:
                         value: column-reference[b]
                       collation: utf8_bin
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # SUBSTRING string function with no for length modifier
 >SELECT SUBSTRING(a FROM 1) FROM t1
 statements:
@@ -216,7 +225,8 @@ statements:
                                       type: VALUE
                                       value: literal[1]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # SUBSTRING string function with a for length modifier
 >SELECT SUBSTRING(a FROM 1 FOR 2) FROM t1
 statements:
@@ -254,7 +264,8 @@ statements:
                                       type: VALUE
                                       value: literal[2]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # UPPER and LOWER string functions
 >SELECT UPPER(a), LOWER(a) FROM t1
 statements:
@@ -289,7 +300,8 @@ statements:
                                 - primary:
                                     value: column-reference[a]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # TRANSLATE string function
 >SELECT TRANSLATE(a USING utf8_bin) FROM t1
 statements:
@@ -312,7 +324,8 @@ statements:
                                     value: column-reference[a]
                           using: utf8_bin
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # CONVERT string function
 >SELECT CONVERT(a USING utf8_bin) FROM t1
 statements:
@@ -335,7 +348,8 @@ statements:
                                     value: column-reference[a]
                           using: utf8_bin
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # TRIM string function with no trim specification or character
 >SELECT TRIM(a) FROM t1
 statements:
@@ -357,7 +371,8 @@ statements:
                                 - primary:
                                     value: column-reference[a]
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # TRIM string function with trim specifications
 >SELECT TRIM(LEADING ' ' FROM a) FROM t1
 statements:
@@ -385,4 +400,5 @@ statements:
                                 - primary:
                                     value: literal[' ']
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1

--- a/tests/grammar/ansi-92/string-expressions.test
+++ b/tests/grammar/ansi-92/string-expressions.test
@@ -207,7 +207,14 @@ statements:
                               factors:
                                 - primary:
                                     value: column-reference[a]
-                          from: literal[1]
+                          start_position:
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[1]
         referenced_tables:
           - t1
 # SUBSTRING string function with a for length modifier
@@ -230,8 +237,22 @@ statements:
                               factors:
                                 - primary:
                                     value: column-reference[a]
-                          from: literal[1]
-                          for: literal[2]
+                          start_position:
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[1]
+                          for_length:
+                            numeric_expression:
+                              term:
+                                left:
+                                  factor:
+                                    primary:
+                                      type: VALUE
+                                      value: literal[2]
         referenced_tables:
           - t1
 # UPPER and LOWER string functions

--- a/tests/grammar/ansi-92/string-expressions.test
+++ b/tests/grammar/ansi-92/string-expressions.test
@@ -379,6 +379,10 @@ statements:
                                 - primary:
                                     value: column-reference[a]
                           specification: LEADING
-                          character: literal[' ']
+                          trim_character:
+                            character_expression:
+                              factors:
+                                - primary:
+                                    value: literal[' ']
         referenced_tables:
           - t1

--- a/tests/grammar/ansi-92/table-references.test
+++ b/tests/grammar/ansi-92/table-references.test
@@ -8,7 +8,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1
+          - type: TABLE
+            table: t1
 # Normal table with an alias using AS keyword
 >SELECT * FROM t1 AS t1_alias
 statements:
@@ -19,7 +20,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1 AS t1_alias
+          - type: TABLE
+            table: t1 AS t1_alias
 # Normal table with an alias NOT using AS keyword
 >SELECT * FROM t1 t1_alias
 statements:
@@ -30,7 +32,8 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - t1 AS t1_alias
+          - type: TABLE
+            table: t1 AS t1_alias
 # Derived table with name using AS keyword
 >SELECT * FROM (SELECT a, b FROM t1) AS t
 statements:
@@ -41,4 +44,5 @@ statements:
           - derived_column:
               asterisk: true
         referenced_tables:
-          - <derived table> AS t
+          - type: DERIVED_TABLE
+            derived_table: <derived table> AS t


### PR DESCRIPTION
Fixes YAML printer output for a variety of value factors, string functions, the like_predicate_t and all table_reference_t's.

Issue #104 