### PR TITLE
Fix insert statement parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ Running ansi-92/drop-view ... OK
 Running ansi-92/grant ... OK
 Running ansi-92/identifiers ... OK
 Running ansi-92/joins ... OK
-Running ansi-92/insert-default-values ... OK
 Running ansi-92/insert-select ... OK
 Running ansi-92/insert-values ... OK
 Running ansi-92/interval-expressions ... OK

--- a/libsqltoast/include/sqltoast/print.h
+++ b/libsqltoast/include/sqltoast/print.h
@@ -133,7 +133,7 @@ std::ostream& operator<< (std::ostream& out, const unsigned_value_specification_
 std::ostream& operator<< (std::ostream& out, const value_expression_primary_t& vep);
 std::ostream& operator<< (std::ostream& out, const value_expression_primary_t& vep);
 std::ostream& operator<< (std::ostream& out, const value_expression_t& ve);
-std::ostream& operator<< (std::ostream& out, const value_subexpression_t& uvs);
+std::ostream& operator<< (std::ostream& out, const parenthesized_value_expression_t& vep);
 
 } // namespace sqltoast
 

--- a/libsqltoast/include/sqltoast/print.h
+++ b/libsqltoast/include/sqltoast/print.h
@@ -66,7 +66,6 @@ std::ostream& operator<< (std::ostream& out, const drop_table_statement_t& stmt)
 std::ostream& operator<< (std::ostream& out, const drop_view_statement_t& stmt);
 std::ostream& operator<< (std::ostream& out, const grant_action_t& action);
 std::ostream& operator<< (std::ostream& out, const grant_statement_t& stmt);
-std::ostream& operator<< (std::ostream& out, const insert_select_statement_t& stmt);
 std::ostream& operator<< (std::ostream& out, const insert_statement_t& stmt);
 std::ostream& operator<< (std::ostream& out, const select_statement_t& stmt);
 std::ostream& operator<< (std::ostream& out, const statement_t& stmt);
@@ -125,6 +124,8 @@ std::ostream& operator<< (std::ostream& out, const substring_function_t& sf);
 std::ostream& operator<< (std::ostream& out, const table_expression_t& te);
 std::ostream& operator<< (std::ostream& out, const table_reference_t& tr);
 std::ostream& operator<< (std::ostream& out, const table_t& t);
+std::ostream& operator<< (std::ostream& out, const table_value_constructor_non_join_query_primary_t& primary);
+std::ostream& operator<< (std::ostream& out, const table_value_constructor_t& table_value);
 std::ostream& operator<< (std::ostream& out, const translate_function_t& tf);
 std::ostream& operator<< (std::ostream& out, const trim_function_t& tf);
 std::ostream& operator<< (std::ostream& out, const unsigned_value_specification_t& uvs);

--- a/libsqltoast/include/sqltoast/query.h
+++ b/libsqltoast/include/sqltoast/query.h
@@ -81,6 +81,23 @@ typedef struct query_specification_non_join_query_primary : non_join_query_prima
     {}
 } query_specification_non_join_query_primary_t;
 
+typedef struct table_value_constructor {
+    std::vector<std::unique_ptr<row_value_constructor_t>> values;
+    table_value_constructor(
+            std::vector<std::unique_ptr<row_value_constructor_t>>& values) :
+        values(std::move(values))
+    {}
+} table_value_constructor_t;
+
+typedef struct table_value_constructor_non_join_query_primary : non_join_query_primary_t {
+    std::unique_ptr<table_value_constructor_t> table_value;
+    table_value_constructor_non_join_query_primary(
+            std::unique_ptr<table_value_constructor_t>& table_value) :
+        non_join_query_primary_t(NON_JOIN_QUERY_PRIMARY_TYPE_TABLE_VALUE_CONSTRUCTOR),
+        table_value(std::move(table_value))
+    {}
+} table_value_constructor_non_join_query_primary_t;
+
 typedef struct non_join_query_term {
     std::unique_ptr<non_join_query_primary_t> primary;
     non_join_query_term(

--- a/libsqltoast/include/sqltoast/statement.h
+++ b/libsqltoast/include/sqltoast/statement.h
@@ -21,7 +21,6 @@ typedef enum statement_type {
     STATEMENT_TYPE_DROP_VIEW,
     STATEMENT_TYPE_GRANT,
     STATEMENT_TYPE_INSERT,
-    STATEMENT_TYPE_INSERT_SELECT,
     STATEMENT_TYPE_ROLLBACK,
     STATEMENT_TYPE_SELECT,
     STATEMENT_TYPE_UPDATE
@@ -201,41 +200,17 @@ typedef struct select_statement : statement_t {
 typedef struct insert_statement : statement_t {
     lexeme_t table_name;
     std::vector<lexeme_t> insert_columns;
-    std::vector<std::unique_ptr<row_value_constructor_t>> insert_values;
+    std::unique_ptr<query_expression_t> query;
     insert_statement(
             lexeme_t& table_name,
             std::vector<lexeme_t>& col_list,
-            std::vector<std::unique_ptr<row_value_constructor_t>>& val_list) :
-        statement_t(STATEMENT_TYPE_INSERT),
-        table_name(table_name),
-        insert_columns(std::move(col_list)),
-        insert_values(std::move(val_list))
-    {}
-    inline bool use_default_columns() const {
-        return insert_columns.empty();
-    }
-    inline bool use_default_values() const {
-        return insert_values.empty();
-    }
-} insert_statement_t;
-
-typedef struct insert_select_statement : statement_t {
-    lexeme_t table_name;
-    std::vector<lexeme_t> insert_columns;
-    std::unique_ptr<query_expression_t> query;
-    insert_select_statement(
-            lexeme_t& table_name,
-            std::vector<lexeme_t>& col_list,
             std::unique_ptr<query_expression_t>& query) :
-        statement_t(STATEMENT_TYPE_INSERT_SELECT),
+        statement_t(STATEMENT_TYPE_INSERT),
         table_name(table_name),
         insert_columns(std::move(col_list)),
         query(std::move(query))
     {}
-    inline bool use_default_columns() const {
-        return insert_columns.empty();
-    }
-} insert_select_statement_t;
+} insert_statement_t;
 
 typedef struct delete_statement : statement_t {
     lexeme_t table_name;

--- a/libsqltoast/include/sqltoast/value.h
+++ b/libsqltoast/include/sqltoast/value.h
@@ -17,7 +17,7 @@ typedef enum vep_type {
     VEP_TYPE_SET_FUNCTION_SPECIFICATION,
     VEP_TYPE_SCALAR_SUBQUERY,
     VEP_TYPE_CASE_EXPRESSION,
-    VEP_TYPE_VALUE_EXPRESSION,
+    VEP_TYPE_PARENTHESIZED_VALUE_EXPRESSION,
     VEP_TYPE_CAST_SPECIFICATION
 } vep_type_t;
 
@@ -203,15 +203,15 @@ typedef struct searched_case_expression : case_expression_t {
 } searched_case_expression_t;
 
 // This is a "subexpression" inside a value expression primary
-typedef struct value_subexpression : value_expression_primary_t {
+typedef struct parenthesized_value_expression : value_expression_primary_t {
     std::unique_ptr<struct value_expression> value;
-    value_subexpression(
+    parenthesized_value_expression(
             std::unique_ptr<struct value_expression>& value,
             lexeme_t lexeme) :
-        value_expression_primary_t(VEP_TYPE_VALUE_EXPRESSION, lexeme),
+        value_expression_primary_t(VEP_TYPE_PARENTHESIZED_VALUE_EXPRESSION, lexeme),
         value(std::move(value))
     {}
-} value_subexpression_t;
+} parenthesized_value_expression_t;
 
 // A value expression primary that contains a subquery that evaluates to a
 // scalar value

--- a/libsqltoast/include/sqltoast/value.h
+++ b/libsqltoast/include/sqltoast/value.h
@@ -239,10 +239,10 @@ typedef struct numeric_primary {
 } numeric_primary_t;
 
 typedef struct numeric_value : numeric_primary_t {
-    std::unique_ptr<value_expression_primary_t> value;
-    numeric_value(std::unique_ptr<value_expression_primary_t>& value) :
+    std::unique_ptr<value_expression_primary_t> primary;
+    numeric_value(std::unique_ptr<value_expression_primary_t>& primary) :
         numeric_primary_t(NUMERIC_PRIMARY_TYPE_VALUE),
-        value(std::move(value))
+        primary(std::move(primary))
     {}
 } numeric_value_t;
 

--- a/libsqltoast/src/parser/parse.h
+++ b/libsqltoast/src/parser/parse.h
@@ -158,6 +158,10 @@ bool parse_table_expression(
         parse_context_t& ctx,
         token_t& cur_tok,
         std::unique_ptr<table_expression_t>& out);
+bool parse_table_value_constructor(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::unique_ptr<table_value_constructor_t>& out);
 
 // Returns true if a table reference can be parsed. If true, the out argument
 // will contain a new pointer to a table_reference_t.

--- a/libsqltoast/src/parser/value.cc
+++ b/libsqltoast/src/parser/value.cc
@@ -144,7 +144,7 @@ check_punc_keywords:
     switch (cur_sym) {
         case SYMBOL_LPAREN:
             cur_tok = lex.next();
-            goto subquery_or_subexpression;
+            goto subquery_or_parenthesized_value_expression;
         case SYMBOL_COUNT:
         case SYMBOL_AVG:
         case SYMBOL_MAX:
@@ -158,7 +158,7 @@ check_punc_keywords:
         default:
             return false;
     }
-subquery_or_subexpression:
+subquery_or_parenthesized_value_expression:
     // There are two possible value expressions that follow a LPAREN: scalar
     // subqueries and precedent value expressions (parens-enclosed value
     // expressions where the parens indicates that the value expression should
@@ -166,7 +166,7 @@ subquery_or_subexpression:
     cur_sym = cur_tok.symbol;
     if (cur_sym == SYMBOL_SELECT)
         goto process_subquery;
-    goto process_subexpression;
+    goto process_parenthesized_value_expression;
 process_subquery:
 {
     parse_position_t subq_start = cur_tok.lexeme.start;
@@ -185,7 +185,7 @@ process_subquery:
     out = std::make_unique<scalar_subquery_t>(subq, vep_lexeme);
     return true;
 }
-process_subexpression:
+process_parenthesized_value_expression:
 {
     parse_position_t inner_val_start = cur_tok.lexeme.start;
     std::unique_ptr<value_expression_t> inner_value;
@@ -200,7 +200,7 @@ process_subexpression:
     cur_tok = lex.next();
     if (ctx.opts.disable_statement_construction)
         return true;
-    out = std::make_unique<value_subexpression_t>(inner_value, vep_lexeme);
+    out = std::make_unique<parenthesized_value_expression_t>(inner_value, vep_lexeme);
     return true;
 }
 err_expect_rparen:

--- a/libsqltoast/src/print/query.cc
+++ b/libsqltoast/src/print/query.cc
@@ -93,6 +93,12 @@ std::ostream& operator<< (std::ostream& out, const non_join_query_primary_t& pri
             }
             break;
         case NON_JOIN_QUERY_PRIMARY_TYPE_TABLE_VALUE_CONSTRUCTOR:
+            {
+                const table_value_constructor_non_join_query_primary_t& sub =
+                    static_cast<const table_value_constructor_non_join_query_primary_t&>(primary);
+                out << sub;
+            }
+            break;
         case NON_JOIN_QUERY_PRIMARY_TYPE_EXPLICIT_TABLE:
         case NON_JOIN_QUERY_PRIMARY_TYPE_SUBEXPRESSION:
             // TODO
@@ -103,6 +109,21 @@ std::ostream& operator<< (std::ostream& out, const non_join_query_primary_t& pri
 
 std::ostream& operator<< (std::ostream& out, const query_specification_non_join_query_primary_t& primary) {
     out << *primary.query_spec;
+    return out;
+}
+
+std::ostream& operator<< (std::ostream& out, const table_value_constructor_non_join_query_primary_t& primary) {
+    out << "values[" << *primary.table_value << ']';
+    return out;
+}
+
+std::ostream& operator<< (std::ostream& out, const table_value_constructor_t& table_value) {
+    size_t x = 0;
+    for (const std::unique_ptr<row_value_constructor_t>& value : table_value.values) {
+        if (x++ > 0)
+            out << ',';
+        out << *value;
+    }
     return out;
 }
 

--- a/libsqltoast/src/print/statement.cc
+++ b/libsqltoast/src/print/statement.cc
@@ -73,13 +73,6 @@ std::ostream& operator<< (std::ostream& out, const statement_t& stmt) {
                 out << sub;
             }
             break;
-        case STATEMENT_TYPE_INSERT_SELECT:
-            {
-                const insert_select_statement_t& sub =
-                    static_cast<const insert_select_statement_t&>(stmt);
-                out << sub;
-            }
-            break;
         case STATEMENT_TYPE_DELETE:
             {
                 const delete_statement_t& sub = static_cast<const delete_statement_t&>(stmt);
@@ -306,36 +299,7 @@ std::ostream& operator<< (std::ostream& out, const insert_statement_t& stmt) {
     out << "<statement: INSERT" << std::endl
         << "   table name: " << stmt.table_name;
 
-    if (stmt.use_default_columns())
-        out << std::endl << "   default columns: true";
-    else {
-        out << std::endl << "   columns:";
-        size_t x = 0;
-        for (const lexeme_t& col : stmt.insert_columns) {
-            out << std::endl << "     " << x++ << ": " << col;
-        }
-    }
-    if (stmt.use_default_values())
-        out << std::endl << "   default values: true";
-    else {
-        size_t x = 0;
-        out << std::endl << "   values:";
-        for (const std::unique_ptr<row_value_constructor_t>& val : stmt.insert_values) {
-            out << std::endl << "     " << x++ << ": " << *val;
-        }
-    }
-    out << ">";
-
-    return out;
-}
-
-std::ostream& operator<< (std::ostream& out, const insert_select_statement_t& stmt) {
-    out << "<statement: INSERT" << std::endl
-        << "   table name: " << stmt.table_name;
-
-    if (stmt.use_default_columns())
-        out << std::endl << "   default columns: true";
-    else {
+    if (! stmt.insert_columns.empty()) {
         out << std::endl << "   columns:";
         size_t x = 0;
         for (const lexeme_t& col : stmt.insert_columns) {

--- a/libsqltoast/src/print/value.cc
+++ b/libsqltoast/src/print/value.cc
@@ -146,10 +146,11 @@ std::ostream& operator<< (std::ostream& out, const value_expression_primary_t& v
                 out << sf;
             }
             break;
-        case VEP_TYPE_VALUE_EXPRESSION:
+        case VEP_TYPE_PARENTHESIZED_VALUE_EXPRESSION:
             {
-                const value_subexpression_t& ve = static_cast<const value_subexpression_t&>(vep);
-                out << "(" << *ve.value << ")";
+                const parenthesized_value_expression_t& ve =
+                    static_cast<const parenthesized_value_expression_t&>(vep);
+                out << "parenthesized-value-expression[" << *ve.value << "]";
             }
             break;
         case VEP_TYPE_CASE_EXPRESSION:

--- a/libsqltoast/src/print/value.cc
+++ b/libsqltoast/src/print/value.cc
@@ -208,7 +208,7 @@ std::ostream& operator<< (std::ostream& out, const unsigned_value_specification_
 }
 
 std::ostream& operator<< (std::ostream& out, const numeric_value_t& nv) {
-    out << *nv.value;
+    out << *nv.primary;
     return out;
 }
 

--- a/sqltoaster/print/yaml.cc
+++ b/sqltoaster/print/yaml.cc
@@ -1241,7 +1241,10 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_primary_
             {
                 const sqltoast::numeric_value_t& sub =
                     static_cast<const sqltoast::numeric_value_t&>(primary);
-                ptr.indent(out) << "value: " << sub;
+                ptr.indent(out) << "value:";
+                ptr.indent_push(out);
+                to_yaml(ptr, out, sub);
+                ptr.indent_pop(out);
             }
             break;
         case sqltoast::NUMERIC_PRIMARY_TYPE_FUNCTION:
@@ -1249,17 +1252,76 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_primary_
             {
                 const sqltoast::numeric_function_t& sub =
                     static_cast<const sqltoast::numeric_function_t&>(primary);
+                ptr.indent(out) << "function:";
+                ptr.indent_push(out);
                 to_yaml(ptr, out, sub);
+                ptr.indent_pop(out);
             }
             break;
     }
     ptr.indent_pop(out);
 }
 
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_value_t& value) {
+    ptr.indent(out) << "primary:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *value.primary);
+    ptr.indent_pop(out);
+}
+
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::value_expression_primary_t& primary) {
+    switch (primary.vep_type) {
+        case sqltoast::VEP_TYPE_UNSIGNED_VALUE_SPECIFICATION:
+            ptr.indent(out) << "type: UNSIGNED_VALUE_SPECIFICATION";
+            {
+                const sqltoast::unsigned_value_specification_t& sub =
+                    static_cast<const sqltoast::unsigned_value_specification_t&>(primary);
+                ptr.indent(out) << "unsigned_value_specification: " << sub;
+            }
+            break;
+        case sqltoast::VEP_TYPE_COLUMN_REFERENCE:
+            ptr.indent(out) << "type: COLUMN_REFERENCE";
+            ptr.indent(out) << "column_reference: " << primary.lexeme;
+            break;
+        case sqltoast::VEP_TYPE_SET_FUNCTION_SPECIFICATION:
+            ptr.indent(out) << "type: SET_FUNCTION_SPECIFICATION";
+            {
+                const sqltoast::set_function_t& sub =
+                    static_cast<const sqltoast::set_function_t&>(primary);
+                ptr.indent(out) << "set_function_specification: " << sub;
+            }
+            break;
+        case sqltoast::VEP_TYPE_PARENTHESIZED_VALUE_EXPRESSION:
+            ptr.indent(out) << "type: PARENTHESIZED_VALUE_EXPRESSION";
+            {
+                const sqltoast::parenthesized_value_expression_t& sub =
+                    static_cast<const sqltoast::parenthesized_value_expression_t&>(primary);
+                ptr.indent(out) << "parenthesized_value_expression: " << *sub.value;
+            }
+            break;
+        case sqltoast::VEP_TYPE_CASE_EXPRESSION:
+            ptr.indent(out) << "type: CASE_EXPRESSION";
+            {
+                const sqltoast::case_expression_t& sub =
+                    static_cast<const sqltoast::case_expression_t&>(primary);
+                ptr.indent(out) << "case_expression: " << sub;
+            }
+            break;
+        case sqltoast::VEP_TYPE_SCALAR_SUBQUERY:
+            ptr.indent(out) << "type: SCALAR_SUBQUERY";
+            {
+                const sqltoast::scalar_subquery_t& sub =
+                    static_cast<const sqltoast::scalar_subquery_t&>(primary);
+                ptr.indent(out) << "scalar_subquery: " << *sub.subquery;
+            }
+            break;
+        default:
+            break;
+    }
+}
+
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_function_t& func) {
     bool found_length_func = false;
-    ptr.indent(out) << "function:";
-    ptr.indent_push(out);
     ptr.indent(out) << "type: ";
     switch (func.type) {
         case sqltoast::NUMERIC_FUNCTION_TYPE_POSITION:
@@ -1299,7 +1361,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_function
             static_cast<const sqltoast::length_expression_t&>(func);
         to_yaml(ptr, out, sub);
     }
-    ptr.indent_pop(out);
 }
 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::length_expression_t& expr) {
@@ -1634,7 +1695,10 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_factor_
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_primary_t& primary) {
     ptr.indent(out) << "primary:";
     ptr.indent_push(out);
-    ptr.indent(out) << "value: " << *primary.value;
+    ptr.indent(out) << "value:";
+    ptr.indent_push(out);
+    to_yaml(ptr, out, *primary.value);
+    ptr.indent_pop(out);
     if (primary.qualifier)
         to_yaml(ptr, out, *primary.qualifier);
     ptr.indent_pop(out);

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -72,6 +72,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_factor_t
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_primary_t& primary);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_term_t& term);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::numeric_value_t& value);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::overlaps_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::position_expression_t& expr);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::predicate_t& pred);
@@ -97,6 +98,7 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::trim_function_t&
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::unique_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::update_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::value_expression_t& ve);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::value_expression_primary_t& primary);
 
 } // namespace sqltoaster::print
 } // namespace sqltoaster

--- a/sqltoaster/print/yaml.h
+++ b/sqltoaster/print/yaml.h
@@ -51,7 +51,6 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_action_t& 
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::grant_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_subquery_predicate_t& pred);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::in_values_predicate_t& pred);
-void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_select_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::insert_statement_t& stmt);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_factor_t& factor);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::interval_primary_t& primary);
@@ -91,6 +90,8 @@ void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::substring_functi
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_t& t);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_expression_t& table_exp);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_reference_t& tr);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_value_constructor_non_join_query_primary_t& primary);
+void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::table_value_constructor_t&);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::translate_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::trim_function_t& func);
 void to_yaml(printer_t& ptr, std::ostream& out, const sqltoast::unique_predicate_t& pred);

--- a/tests/grammar/ansi-92/case-expressions.test
+++ b/tests/grammar/ansi-92/case-expressions.test
@@ -26,7 +26,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: coalesce[column-reference[a],literal['n/a']]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: coalesce[column-reference[a],literal['n/a']]
         referenced_tables:
           - type: TABLE
             table:
@@ -47,7 +50,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: coalesce[column-reference[a],column-reference[b],column-reference[c],literal['n/a']]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: coalesce[column-reference[a],column-reference[b],column-reference[c],literal['n/a']]
         referenced_tables:
           - type: TABLE
             table:
@@ -68,7 +74,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: nullif[column-reference[a],literal['n/a']]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: nullif[column-reference[a],literal['n/a']]
         referenced_tables:
           - type: TABLE
             table:
@@ -89,7 +98,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2]]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2]]
         referenced_tables:
           - type: TABLE
             table:
@@ -110,7 +122,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3]]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3]]
         referenced_tables:
           - type: TABLE
             table:
@@ -131,7 +146,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] ELSE literal[42]]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] ELSE literal[42]]
         referenced_tables:
           - type: TABLE
             table:
@@ -152,7 +170,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3] ELSE literal[4]]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: simple-case-expression[column-reference[a] WHEN literal[1] THEN literal[2] WHEN literal[2] THEN literal[3] ELSE literal[4]]
         referenced_tables:
           - type: TABLE
             table:
@@ -173,7 +194,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2]]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2]]
         referenced_tables:
           - type: TABLE
             table:
@@ -194,7 +218,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3]]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3]]
         referenced_tables:
           - type: TABLE
             table:
@@ -215,7 +242,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] ELSE literal[42]]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] ELSE literal[42]]
         referenced_tables:
           - type: TABLE
             table:
@@ -236,7 +266,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3] ELSE literal[4]]
+                          value:
+                            primary:
+                              type: CASE_EXPRESSION
+                              case_expression: searched-case-expression[WHEN column-reference[a] = literal[1] THEN literal[2] WHEN column-reference[a] = literal[2] THEN literal[3] ELSE literal[4]]
         referenced_tables:
           - type: TABLE
             table:

--- a/tests/grammar/ansi-92/create-view.test
+++ b/tests/grammar/ansi-92/create-view.test
@@ -43,7 +43,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: column-reference[a]
+                          value:
+                            primary:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -53,7 +56,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: column-reference[b]
+                          value:
+                            primary:
+                              type: COLUMN_REFERENCE
+                              column_reference: b
         referenced_tables:
           - type: TABLE
             table:

--- a/tests/grammar/ansi-92/datetime-expressions.test
+++ b/tests/grammar/ansi-92/datetime-expressions.test
@@ -198,7 +198,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[b]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: b
                             qualifier:
                               start:
                                 interval: YEAR
@@ -232,7 +234,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[b]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: b
                             qualifier:
                               start:
                                 interval: DAY

--- a/tests/grammar/ansi-92/delete.test
+++ b/tests/grammar/ansi-92/delete.test
@@ -30,7 +30,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: column-reference[a]
+                                    value:
+                                      primary:
+                                        type: COLUMN_REFERENCE
+                                        column_reference: a
                   right:
                     row_value_constructor:
                       type: ELEMENT
@@ -44,4 +47,7 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[10]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[10]

--- a/tests/grammar/ansi-92/identifiers.test
+++ b/tests/grammar/ansi-92/identifiers.test
@@ -66,7 +66,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: column-reference[t1.*]
+                          value:
+                            primary:
+                              type: COLUMN_REFERENCE
+                              column_reference: t1.*
         referenced_tables:
           - type: TABLE
             table:

--- a/tests/grammar/ansi-92/insert-default-values.test
+++ b/tests/grammar/ansi-92/insert-default-values.test
@@ -1,7 +1,0 @@
->INSERT INTO t1 DEFAULT VALUES
-statements:
-  - type: INSERT
-    insert_statement:
-      table_name: t1
-      default_columns: true
-      default_values: true

--- a/tests/grammar/ansi-92/insert-select.test
+++ b/tests/grammar/ansi-92/insert-select.test
@@ -1,10 +1,9 @@
 # INSERT SELECT with default columns
 >INSERT INTO t1 SELECT a, b FROM t1
 statements:
-  - type: INSERT_SELECT
-    insert_select_statement:
+  - type: INSERT
+    insert_statement:
       table_name: t1
-      default_columns: true
       query:
         selected_columns:
           - derived_column:
@@ -34,8 +33,8 @@ statements:
 # INSERT SELECT with target columns and a search condition
 >INSERT INTO t1 (t1_a, t1_b) SELECT a, b FROM t1 WHERE c < 3
 statements:
-  - type: INSERT_SELECT
-    insert_select_statement:
+  - type: INSERT
+    insert_statement:
       table_name: t1
       columns:
         - t1_a

--- a/tests/grammar/ansi-92/insert-select.test
+++ b/tests/grammar/ansi-92/insert-select.test
@@ -15,7 +15,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: column-reference[a]
+                          value:
+                            primary:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -25,7 +28,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: column-reference[b]
+                          value:
+                            primary:
+                              type: COLUMN_REFERENCE
+                              column_reference: b
         referenced_tables:
           - type: TABLE
             table:
@@ -50,7 +56,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: column-reference[a]
+                          value:
+                            primary:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -60,7 +69,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: column-reference[b]
+                          value:
+                            primary:
+                              type: COLUMN_REFERENCE
+                              column_reference: b
         referenced_tables:
           - type: TABLE
             table:
@@ -85,7 +97,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[c]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: c
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -99,4 +114,7 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[3]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[3]

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -1,3 +1,9 @@
+>INSERT INTO t1 DEFAULT VALUES
+statements:
+  - type: INSERT
+    insert_statement:
+      table_name: t1
+      default_values: true
 >INSERT INTO t1 (a, b) VALUES (1, 2)
 statements:
   - type: INSERT
@@ -6,86 +12,81 @@ statements:
       columns:
         - a
         - b
-      values:
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: NUMERIC_EXPRESSION
-                numeric_expression:
-                  term:
-                    left:
-                      factor:
-                        primary:
-                          type: VALUE
-                          value: literal[1]
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: NUMERIC_EXPRESSION
-                numeric_expression:
-                  term:
-                    left:
-                      factor:
-                        primary:
-                          type: VALUE
-                          value: literal[2]
+      query:
+        values:
+          - row_value_constructor:
+              type: LIST
+              elements:
+                - type: VALUE_EXPRESSION
+                  value_expression:
+                    type: NUMERIC_EXPRESSION
+                    numeric_expression:
+                      term:
+                        left:
+                          factor:
+                            primary:
+                              type: VALUE
+                              value: literal[1]
+                - type: VALUE_EXPRESSION
+                  value_expression:
+                    type: NUMERIC_EXPRESSION
+                    numeric_expression:
+                      term:
+                        left:
+                          factor:
+                            primary:
+                              type: VALUE
+                              value: literal[2]
 # INSERT INTO with a default columns list
 >INSERT INTO t1 VALUES (1, 2)
 statements:
   - type: INSERT
     insert_statement:
       table_name: t1
-      default_columns: true
-      values:
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: NUMERIC_EXPRESSION
-                numeric_expression:
-                  term:
-                    left:
-                      factor:
-                        primary:
-                          type: VALUE
-                          value: literal[1]
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: NUMERIC_EXPRESSION
-                numeric_expression:
-                  term:
-                    left:
-                      factor:
-                        primary:
-                          type: VALUE
-                          value: literal[2]
+      query:
+        values:
+          - row_value_constructor:
+              type: LIST
+              elements:
+                - type: VALUE_EXPRESSION
+                  value_expression:
+                    type: NUMERIC_EXPRESSION
+                    numeric_expression:
+                      term:
+                        left:
+                          factor:
+                            primary:
+                              type: VALUE
+                              value: literal[1]
+                - type: VALUE_EXPRESSION
+                  value_expression:
+                    type: NUMERIC_EXPRESSION
+                    numeric_expression:
+                      term:
+                        left:
+                          factor:
+                            primary:
+                              type: VALUE
+                              value: literal[2]
 # INSERT INTO using a character values expression
->INSERT INTO t1 VALUES ('a' COLLATE utf8bin)
-statements:
-  - type: INSERT
-    insert_statement:
-      table_name: t1
-      default_columns: true
-      values:
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: STRING_EXPRESSION
-                character_expression:
-                  factors:
-                    - primary:
-                        value: literal['a']
-                      collation: utf8bin
+# >INSERT INTO t1 VALUES ('a' COLLATE utf8bin)
+# statements:
+#   - type: INSERT
+#     insert_statement:
+#       table_name: t1
+#       query:
+#         values:
+#           - row_value_constructor:
+#               type: LIST
+#               elements:
+#                 - type: VALUE_EXPRESSION
+#                   value_expression:
+#                     type: STRING_EXPRESSION
+#                     character_expression:
+#                       factors:
+#                         - primary:
+#                             value: literal['a']
+#                           collation: utf8bin
 # INSERT INTO using datetime value expressions
 >INSERT INTO t1 (create_date, my_date) VALUES (CURRENT_DATE, '2001-01-01' AT TIME ZONE 'UTC')
 statements:
@@ -95,90 +96,90 @@ statements:
       columns:
         - create_date
         - my_date
-      values:
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: DATETIME_EXPRESSION
-                datetime_expression:
-                  left:
-                    term:
-                      factor:
-                        time_zone: LOCAL
-                        primary:
-                          type: FUNCTION
-                          function: current-date[]
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: DATETIME_EXPRESSION
-                datetime_expression:
-                  left:
-                    term:
-                      factor:
-                        time_zone: 'UTC'
-                        primary:
-                          type: VALUE
-                          value: literal['2001-01-01']
+      query:
+        values:
+          - row_value_constructor:
+              type: LIST
+              elements:
+                - type: VALUE_EXPRESSION
+                  value_expression:
+                    type: DATETIME_EXPRESSION
+                    datetime_expression:
+                      left:
+                        term:
+                          factor:
+                            time_zone: LOCAL
+                            primary:
+                              type: FUNCTION
+                              function: current-date[]
+                - type: VALUE_EXPRESSION
+                  value_expression:
+                    type: DATETIME_EXPRESSION
+                    datetime_expression:
+                      left:
+                        term:
+                          factor:
+                            time_zone: 'UTC'
+                            primary:
+                              type: VALUE
+                              value: literal['2001-01-01']
 # INSERT INTO using interval value expressions
->INSERT INTO t1 (num_seconds) VALUES ('2001-01-01' DAY TO SECOND)
-statements:
-  - type: INSERT
-    insert_statement:
-      table_name: t1
-      columns:
-        - num_seconds
-      values:
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: INTERVAL_EXPRESSION
-                interval_expression:
-                  left:
-                    term:
-                      left:
-                        factor:
-                          primary:
-                            value: literal['2001-01-01']
-                            qualifier:
-                              start:
-                                interval: DAY
-                              end:
-                                interval: SECOND
+# >INSERT INTO t1 (num_seconds) VALUES ('2001-01-01' DAY TO SECOND)
+# statements:
+#   - type: INSERT
+#     insert_statement:
+#       table_name: t1
+#       columns:
+#         - num_seconds
+#       query:
+#         values:
+#           - row_value_constructor:
+#               type: LIST
+#               elements:
+#                 - type: VALUE_EXPRESSION
+#                   value_expression:
+#                     type: INTERVAL_EXPRESSION
+#                     interval_expression:
+#                       left:
+#                         term:
+#                           left:
+#                             factor:
+#                               primary:
+#                                 value: literal['2001-01-01']
+#                                 qualifier:
+#                                   start:
+#                                     interval: DAY
+#                                   end:
+#                                     interval: SECOND
 # INSERT INTO using numeric value expressions
->INSERT INTO t1 (num_seconds) VALUES (1 + (2 * 3))
-statements:
-  - type: INSERT
-    insert_statement:
-      table_name: t1
-      columns:
-        - num_seconds
-      values:
-        - row_value_constructor:
-            type: ELEMENT
-            element:
-              type: VALUE_EXPRESSION
-              value_expression:
-                type: NUMERIC_EXPRESSION
-                numeric_expression:
-                  left:
-                    term:
-                      left:
-                        factor:
-                          primary:
-                            type: VALUE
-                            value: literal[1]
-                  op: ADD
-                  right:
-                    term:
-                      left:
-                        factor:
-                          primary:
-                            type: VALUE
-                            value: (numeric-expression[literal[2] * literal[3]])
+# >INSERT INTO t1 (num_seconds) VALUES (1 + (2 * 3))
+# statements:
+#   - type: INSERT
+#     insert_statement:
+#       table_name: t1
+#       columns:
+#         - num_seconds
+#       query:
+#         values:
+#           - row_value_constructor:
+#               type: LIST
+#               elements:
+#                 - type: VALUE_EXPRESSION
+#                   value_expression:
+#                     type: NUMERIC_EXPRESSION
+#                     numeric_expression:
+#                       left:
+#                         term:
+#                           left:
+#                             factor:
+#                               primary:
+#                                 type: VALUE
+#                                 value: literal[1]
+#                       op: ADD
+#                       right:
+#                         term:
+#                           left:
+#                             factor:
+#                               primary:
+#                                 type: VALUE
+#                                 value: (numeric-expression[literal[2] * literal[3]])

--- a/tests/grammar/ansi-92/insert-values.test
+++ b/tests/grammar/ansi-92/insert-values.test
@@ -26,7 +26,10 @@ statements:
                           factor:
                             primary:
                               type: VALUE
-                              value: literal[1]
+                              value:
+                                primary:
+                                  type: UNSIGNED_VALUE_SPECIFICATION
+                                  unsigned_value_specification: literal[1]
                 - type: VALUE_EXPRESSION
                   value_expression:
                     type: NUMERIC_EXPRESSION
@@ -36,7 +39,10 @@ statements:
                           factor:
                             primary:
                               type: VALUE
-                              value: literal[2]
+                              value:
+                                primary:
+                                  type: UNSIGNED_VALUE_SPECIFICATION
+                                  unsigned_value_specification: literal[2]
 # INSERT INTO with a default columns list
 >INSERT INTO t1 VALUES (1, 2)
 statements:
@@ -57,7 +63,10 @@ statements:
                           factor:
                             primary:
                               type: VALUE
-                              value: literal[1]
+                              value:
+                                primary:
+                                  type: UNSIGNED_VALUE_SPECIFICATION
+                                  unsigned_value_specification: literal[1]
                 - type: VALUE_EXPRESSION
                   value_expression:
                     type: NUMERIC_EXPRESSION
@@ -67,7 +76,10 @@ statements:
                           factor:
                             primary:
                               type: VALUE
-                              value: literal[2]
+                              value:
+                                primary:
+                                  type: UNSIGNED_VALUE_SPECIFICATION
+                                  unsigned_value_specification: literal[2]
 # INSERT INTO using a character values expression
 # >INSERT INTO t1 VALUES ('a' COLLATE utf8bin)
 # statements:

--- a/tests/grammar/ansi-92/interval-expressions.test
+++ b/tests/grammar/ansi-92/interval-expressions.test
@@ -14,7 +14,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: YEAR
@@ -39,7 +41,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: DAY
@@ -65,7 +69,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: SECOND
@@ -91,7 +97,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: SECOND
@@ -118,7 +126,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: YEAR
@@ -145,7 +155,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: DAY
@@ -172,7 +184,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: DAY
@@ -201,7 +215,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: YEAR
@@ -210,7 +226,10 @@ statements:
                         factor:
                           primary:
                             type: VALUE
-                            value: literal[12]
+                            value:
+                              primary:
+                                type: UNSIGNED_VALUE_SPECIFICATION
+                                unsigned_value_specification: literal[12]
           - derived_column:
               value_expression:
                 type: INTERVAL_EXPRESSION
@@ -220,7 +239,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: YEAR
@@ -229,7 +250,10 @@ statements:
                         factor:
                           primary:
                             type: VALUE
-                            value: literal[2]
+                            value:
+                              primary:
+                                type: UNSIGNED_VALUE_SPECIFICATION
+                                unsigned_value_specification: literal[2]
           - derived_column:
               value_expression:
                 type: INTERVAL_EXPRESSION
@@ -239,7 +263,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: MONTH
@@ -248,7 +274,10 @@ statements:
                         factor:
                           primary:
                             type: VALUE
-                            value: parenthesized-value-expression[numeric-expression[literal[12] / column-reference[b]]]
+                            value:
+                              primary:
+                                type: PARENTHESIZED_VALUE_EXPRESSION
+                                parenthesized_value_expression: numeric-expression[literal[12] / column-reference[b]]
         referenced_tables:
           - type: TABLE
             table:
@@ -270,7 +299,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[a]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: a
                             qualifier:
                               start:
                                 interval: YEAR
@@ -280,7 +311,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: literal[12]
+                            value:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: literal[12]
                             qualifier:
                               start:
                                 interval: YEAR
@@ -293,7 +326,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[created_on]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: created_on
                             qualifier:
                               start:
                                 interval: DAY
@@ -305,7 +340,9 @@ statements:
                       left:
                         factor:
                           primary:
-                            value: column-reference[updated_on]
+                            value:
+                              type: COLUMN_REFERENCE
+                              column_reference: updated_on
                             qualifier:
                               start:
                                 interval: DAY

--- a/tests/grammar/ansi-92/interval-expressions.test
+++ b/tests/grammar/ansi-92/interval-expressions.test
@@ -248,7 +248,7 @@ statements:
                         factor:
                           primary:
                             type: VALUE
-                            value: (numeric-expression[literal[12] / column-reference[b]])
+                            value: parenthesized-value-expression[numeric-expression[literal[12] / column-reference[b]]]
         referenced_tables:
           - type: TABLE
             table:

--- a/tests/grammar/ansi-92/joins.test
+++ b/tests/grammar/ansi-92/joins.test
@@ -67,7 +67,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t1.id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t1.id
                             right:
                               row_value_constructor:
                                 type: ELEMENT
@@ -81,7 +84,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t2.t1_id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t2.t1_id
 # INNER JOIN two normal tables WITH the INNER symbol
 >SELECT * FROM t1 INNER JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -124,7 +130,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t1.id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t1.id
                             right:
                               row_value_constructor:
                                 type: ELEMENT
@@ -138,7 +147,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t2.t1_id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t2.t1_id
 # INNER JOIN two normal tables with no join condition
 >SELECT * FROM t1 JOIN t2
 statements:
@@ -202,7 +214,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t1.id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t1.id
                             right:
                               row_value_constructor:
                                 type: ELEMENT
@@ -216,7 +231,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t2.t1_id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t2.t1_id
 # LEFT JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -259,7 +277,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t1.id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t1.id
                             right:
                               row_value_constructor:
                                 type: ELEMENT
@@ -273,7 +294,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t2.t1_id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t2.t1_id
 # RIGHT JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 RIGHT JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -316,7 +340,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t1.id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t1.id
                             right:
                               row_value_constructor:
                                 type: ELEMENT
@@ -330,7 +357,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t2.t1_id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t2.t1_id
 # RIGHT JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -373,7 +403,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t1.id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t1.id
                             right:
                               row_value_constructor:
                                 type: ELEMENT
@@ -387,7 +420,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t2.t1_id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t2.t1_id
 # FULL OUTER JOIN two normal tables WITHOUT the optional OUTER symbol
 >SELECT * FROM t1 FULL JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -430,7 +466,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t1.id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t1.id
                             right:
                               row_value_constructor:
                                 type: ELEMENT
@@ -444,7 +483,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t2.t1_id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t2.t1_id
 # FULL OUTER JOIN two normal tables WITH the optional OUTER symbol
 >SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.t1_id
 statements:
@@ -487,7 +529,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t1.id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t1.id
                             right:
                               row_value_constructor:
                                 type: ELEMENT
@@ -501,7 +546,10 @@ statements:
                                           factor:
                                             primary:
                                               type: VALUE
-                                              value: column-reference[t2.t1_id]
+                                              value:
+                                                primary:
+                                                  type: COLUMN_REFERENCE
+                                                  column_reference: t2.t1_id
 # JOIN with USING clause
 >SELECT * FROM t1 JOIN t2 USING (id)
 statements:

--- a/tests/grammar/ansi-92/numeric-expressions.test
+++ b/tests/grammar/ansi-92/numeric-expressions.test
@@ -14,7 +14,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: literal[1]
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: literal[1]
         referenced_tables:
           - type: TABLE
             table:
@@ -47,7 +50,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: column-reference[a]
+                                    value:
+                                      primary:
+                                        type: COLUMN_REFERENCE
+                                        column_reference: a
                   right:
                     row_value_constructor:
                       type: ELEMENT
@@ -61,7 +67,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: parenthesized-value-expression[numeric-expression[literal[2] + column-reference[b]]]
+                                    value:
+                                      primary:
+                                        type: PARENTHESIZED_VALUE_EXPRESSION
+                                        parenthesized_value_expression: numeric-expression[literal[2] + column-reference[b]]
 # Simple subtraction of literal number from column reference
 >UPDATE t1 SET x = 1 WHERE a = (b - 2)
 statements:
@@ -90,7 +99,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: column-reference[a]
+                                    value:
+                                      primary:
+                                        type: COLUMN_REFERENCE
+                                        column_reference: a
                   right:
                     row_value_constructor:
                       type: ELEMENT
@@ -104,7 +116,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: parenthesized-value-expression[numeric-expression[column-reference[b] - literal[2]]]
+                                    value:
+                                      primary:
+                                        type: PARENTHESIZED_VALUE_EXPRESSION
+                                        parenthesized_value_expression: numeric-expression[column-reference[b] - literal[2]]
 # Simple multiplication of two literals
 >UPDATE t1 SET x = 1 WHERE a = (2 * 1)
 statements:
@@ -133,7 +148,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: column-reference[a]
+                                    value:
+                                      primary:
+                                        type: COLUMN_REFERENCE
+                                        column_reference: a
                   right:
                     row_value_constructor:
                       type: ELEMENT
@@ -147,7 +165,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: parenthesized-value-expression[numeric-expression[literal[2] * literal[1]]]
+                                    value:
+                                      primary:
+                                        type: PARENTHESIZED_VALUE_EXPRESSION
+                                        parenthesized_value_expression: numeric-expression[literal[2] * literal[1]]
 # Simple division of two literals
 >UPDATE t1 SET x = 1 WHERE a = (1 / 2)
 statements:
@@ -176,7 +197,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: column-reference[a]
+                                    value:
+                                      primary:
+                                        type: COLUMN_REFERENCE
+                                        column_reference: a
                   right:
                     row_value_constructor:
                       type: ELEMENT
@@ -190,7 +214,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: parenthesized-value-expression[numeric-expression[literal[1] / literal[2]]]
+                                    value:
+                                      primary:
+                                        type: PARENTHESIZED_VALUE_EXPRESSION
+                                        parenthesized_value_expression: numeric-expression[literal[1] / literal[2]]
 # Addition of numeric expression to a literal
 >UPDATE t1 SET x = 1 WHERE a = (1 + (2 * 1))
 statements:
@@ -219,7 +246,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: column-reference[a]
+                                    value:
+                                      primary:
+                                        type: COLUMN_REFERENCE
+                                        column_reference: a
                   right:
                     row_value_constructor:
                       type: ELEMENT
@@ -233,7 +263,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: parenthesized-value-expression[numeric-expression[literal[1] + parenthesized-value-expression[numeric-expression[literal[2] * literal[1]]]]]
+                                    value:
+                                      primary:
+                                        type: PARENTHESIZED_VALUE_EXPRESSION
+                                        parenthesized_value_expression: numeric-expression[literal[1] + parenthesized-value-expression[numeric-expression[literal[2] * literal[1]]]]
 # General value expression primaries
 >SELECT USER, CURRENT_USER, SESSION_USER, SYSTEM_USER, VALUE FROM t1
 statements:
@@ -250,7 +283,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: USER
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: USER
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -260,7 +296,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: CURRENT_USER
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: CURRENT_USER
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -270,7 +309,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: SESSION_USER
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: SESSION_USER
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -280,7 +322,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: SYSTEM_USER
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: SYSTEM_USER
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -290,7 +335,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: VALUE
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: VALUE
         referenced_tables:
           - type: TABLE
             table:
@@ -311,7 +359,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: COUNT(*)
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: COUNT(*)
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -321,7 +372,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: COUNT(DISTINCT column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: COUNT(DISTINCT column-reference[a])
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -331,7 +385,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: COUNT(column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: COUNT(column-reference[a])
         referenced_tables:
           - type: TABLE
             table:
@@ -352,7 +409,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: SUM(DISTINCT column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: SUM(DISTINCT column-reference[a])
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -362,7 +422,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: SUM(column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: SUM(column-reference[a])
         referenced_tables:
           - type: TABLE
             table:
@@ -383,7 +446,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: AVG(DISTINCT column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: AVG(DISTINCT column-reference[a])
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -393,7 +459,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: AVG(column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: AVG(column-reference[a])
         referenced_tables:
           - type: TABLE
             table:
@@ -414,7 +483,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: MIN(DISTINCT column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: MIN(DISTINCT column-reference[a])
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -424,7 +496,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: MIN(column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: MIN(column-reference[a])
         referenced_tables:
           - type: TABLE
             table:
@@ -445,7 +520,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: MAX(DISTINCT column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: MAX(DISTINCT column-reference[a])
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -455,7 +533,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: MAX(column-reference[a])
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: MAX(column-reference[a])
         referenced_tables:
           - type: TABLE
             table:
@@ -476,7 +557,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: MAX(COUNT(column-reference[a]))
+                          value:
+                            primary:
+                              type: SET_FUNCTION_SPECIFICATION
+                              set_function_specification: MAX(COUNT(column-reference[a]))
         referenced_tables:
           - type: TABLE
             table:
@@ -520,7 +604,10 @@ statements:
                         factor:
                           primary:
                             type: VALUE
-                            value: literal[1]
+                            value:
+                              primary:
+                                type: UNSIGNED_VALUE_SPECIFICATION
+                                unsigned_value_specification: literal[1]
         referenced_tables:
           - type: TABLE
             table:

--- a/tests/grammar/ansi-92/numeric-expressions.test
+++ b/tests/grammar/ansi-92/numeric-expressions.test
@@ -61,7 +61,7 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: (numeric-expression[literal[2] + column-reference[b]])
+                                    value: parenthesized-value-expression[numeric-expression[literal[2] + column-reference[b]]]
 # Simple subtraction of literal number from column reference
 >UPDATE t1 SET x = 1 WHERE a = (b - 2)
 statements:
@@ -104,7 +104,7 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: (numeric-expression[column-reference[b] - literal[2]])
+                                    value: parenthesized-value-expression[numeric-expression[column-reference[b] - literal[2]]]
 # Simple multiplication of two literals
 >UPDATE t1 SET x = 1 WHERE a = (2 * 1)
 statements:
@@ -147,7 +147,7 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: (numeric-expression[literal[2] * literal[1]])
+                                    value: parenthesized-value-expression[numeric-expression[literal[2] * literal[1]]]
 # Simple division of two literals
 >UPDATE t1 SET x = 1 WHERE a = (1 / 2)
 statements:
@@ -190,7 +190,7 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: (numeric-expression[literal[1] / literal[2]])
+                                    value: parenthesized-value-expression[numeric-expression[literal[1] / literal[2]]]
 # Addition of numeric expression to a literal
 >UPDATE t1 SET x = 1 WHERE a = (1 + (2 * 1))
 statements:
@@ -233,7 +233,7 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: (numeric-expression[literal[1] + (numeric-expression[literal[2] * literal[1]])])
+                                    value: parenthesized-value-expression[numeric-expression[literal[1] + parenthesized-value-expression[numeric-expression[literal[2] * literal[1]]]]]
 # General value expression primaries
 >SELECT USER, CURRENT_USER, SESSION_USER, SYSTEM_USER, VALUE FROM t1
 statements:

--- a/tests/grammar/ansi-92/predicates.test
+++ b/tests/grammar/ansi-92/predicates.test
@@ -31,7 +31,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -45,7 +48,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[10]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[10]
 # anti-equality comparison predicate
 >SELECT * FROM t1 WHERE a <> 10
 statements:
@@ -79,7 +85,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -93,7 +102,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[10]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[10]
 # Order of value expressions should not matter in equality comparison
 >SELECT * FROM t1 WHERE 10 = a
 statements:
@@ -127,7 +139,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[10]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[10]
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -141,7 +156,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
 # Compound predicate with AND of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 AND b = 2
 statements:
@@ -175,7 +193,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -189,7 +210,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
                 and:
                   factor:
                     predicate:
@@ -208,7 +232,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[b]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: b
                       right:
                         row_value_constructor:
                           type: ELEMENT
@@ -222,7 +249,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: literal[2]
+                                        value:
+                                          primary:
+                                            type: UNSIGNED_VALUE_SPECIFICATION
+                                            unsigned_value_specification: literal[2]
 # Compound predicate with OR of two equality comparison predicates
 >SELECT * FROM t1 WHERE a = 1 OR b = 2
 statements:
@@ -256,7 +286,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -270,7 +303,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
               - factor:
                   predicate:
                     type: COMPARISON
@@ -288,7 +324,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[b]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: b
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -302,7 +341,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[2]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[2]
 # Compound predicate with both AND and OR operators
 >SELECT * FROM t1 WHERE a = 1 AND b = 2 OR c = 3
 statements:
@@ -336,7 +378,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -350,7 +395,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
                 and:
                   factor:
                     predicate:
@@ -369,7 +417,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[b]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: b
                       right:
                         row_value_constructor:
                           type: ELEMENT
@@ -383,7 +434,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: literal[2]
+                                        value:
+                                          primary:
+                                            type: UNSIGNED_VALUE_SPECIFICATION
+                                            unsigned_value_specification: literal[2]
               - factor:
                   predicate:
                     type: COMPARISON
@@ -401,7 +455,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[c]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: c
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -415,7 +472,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[3]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[3]
 # Compound predicate with both OR and AND operators. The AND should take
 # precedence
 >SELECT * FROM t1 WHERE a = 1 OR b = 2 AND c = 3
@@ -450,7 +510,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -464,7 +527,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
               - factor:
                   predicate:
                     type: COMPARISON
@@ -482,7 +548,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[b]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: b
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -496,7 +565,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[2]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[2]
                 and:
                   factor:
                     predicate:
@@ -515,7 +587,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[c]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: c
                       right:
                         row_value_constructor:
                           type: ELEMENT
@@ -529,7 +604,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: literal[3]
+                                        value:
+                                          primary:
+                                            type: UNSIGNED_VALUE_SPECIFICATION
+                                            unsigned_value_specification: literal[3]
 # Compound predicate with both AND and OR operators using parens for precedence
 # override
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3)
@@ -564,7 +642,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -578,7 +659,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
                 and:
                   factor:
                     search_condition:
@@ -600,7 +684,10 @@ statements:
                                             factor:
                                               primary:
                                                 type: VALUE
-                                                value: column-reference[b]
+                                                value:
+                                                  primary:
+                                                    type: COLUMN_REFERENCE
+                                                    column_reference: b
                               right:
                                 row_value_constructor:
                                   type: ELEMENT
@@ -614,7 +701,10 @@ statements:
                                             factor:
                                               primary:
                                                 type: VALUE
-                                                value: literal[2]
+                                                value:
+                                                  primary:
+                                                    type: UNSIGNED_VALUE_SPECIFICATION
+                                                    unsigned_value_specification: literal[2]
                         - factor:
                             predicate:
                               type: COMPARISON
@@ -632,7 +722,10 @@ statements:
                                             factor:
                                               primary:
                                                 type: VALUE
-                                                value: column-reference[c]
+                                                value:
+                                                  primary:
+                                                    type: COLUMN_REFERENCE
+                                                    column_reference: c
                               right:
                                 row_value_constructor:
                                   type: ELEMENT
@@ -646,7 +739,10 @@ statements:
                                             factor:
                                               primary:
                                                 type: VALUE
-                                                value: literal[3]
+                                                value:
+                                                  primary:
+                                                    type: UNSIGNED_VALUE_SPECIFICATION
+                                                    unsigned_value_specification: literal[3]
 # Multiple nested search conditions using parens for precedence
 >SELECT * FROM t1 WHERE a = 1 AND (b = 2 OR c = 3 AND (d = 4 OR e = 5))
 statements:
@@ -680,7 +776,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -694,7 +793,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
                 and:
                   factor:
                     search_condition:
@@ -716,7 +818,10 @@ statements:
                                             factor:
                                               primary:
                                                 type: VALUE
-                                                value: column-reference[b]
+                                                value:
+                                                  primary:
+                                                    type: COLUMN_REFERENCE
+                                                    column_reference: b
                               right:
                                 row_value_constructor:
                                   type: ELEMENT
@@ -730,7 +835,10 @@ statements:
                                             factor:
                                               primary:
                                                 type: VALUE
-                                                value: literal[2]
+                                                value:
+                                                  primary:
+                                                    type: UNSIGNED_VALUE_SPECIFICATION
+                                                    unsigned_value_specification: literal[2]
                         - factor:
                             predicate:
                               type: COMPARISON
@@ -748,7 +856,10 @@ statements:
                                             factor:
                                               primary:
                                                 type: VALUE
-                                                value: column-reference[c]
+                                                value:
+                                                  primary:
+                                                    type: COLUMN_REFERENCE
+                                                    column_reference: c
                               right:
                                 row_value_constructor:
                                   type: ELEMENT
@@ -762,7 +873,10 @@ statements:
                                             factor:
                                               primary:
                                                 type: VALUE
-                                                value: literal[3]
+                                                value:
+                                                  primary:
+                                                    type: UNSIGNED_VALUE_SPECIFICATION
+                                                    unsigned_value_specification: literal[3]
                           and:
                             factor:
                               search_condition:
@@ -784,7 +898,10 @@ statements:
                                                       factor:
                                                         primary:
                                                           type: VALUE
-                                                          value: column-reference[d]
+                                                          value:
+                                                            primary:
+                                                              type: COLUMN_REFERENCE
+                                                              column_reference: d
                                         right:
                                           row_value_constructor:
                                             type: ELEMENT
@@ -798,7 +915,10 @@ statements:
                                                       factor:
                                                         primary:
                                                           type: VALUE
-                                                          value: literal[4]
+                                                          value:
+                                                            primary:
+                                                              type: UNSIGNED_VALUE_SPECIFICATION
+                                                              unsigned_value_specification: literal[4]
                                   - factor:
                                       predicate:
                                         type: COMPARISON
@@ -816,7 +936,10 @@ statements:
                                                       factor:
                                                         primary:
                                                           type: VALUE
-                                                          value: column-reference[e]
+                                                          value:
+                                                            primary:
+                                                              type: COLUMN_REFERENCE
+                                                              column_reference: e
                                         right:
                                           row_value_constructor:
                                             type: ELEMENT
@@ -830,7 +953,10 @@ statements:
                                                       factor:
                                                         primary:
                                                           type: VALUE
-                                                          value: literal[5]
+                                                          value:
+                                                            primary:
+                                                              type: UNSIGNED_VALUE_SPECIFICATION
+                                                              unsigned_value_specification: literal[5]
 # IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE a IN (1)
 statements:
@@ -863,7 +989,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     values:
                       - value_expression:
                           type: NUMERIC_EXPRESSION
@@ -873,7 +1002,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[1]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[1]
 # Negate of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE a NOT IN (1)
 statements:
@@ -906,7 +1038,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     negate: true
                     values:
                       - value_expression:
@@ -917,7 +1052,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[1]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[1]
 # top-level negation of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE NOT a IN (1)
 statements:
@@ -950,7 +1088,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     values:
                       - value_expression:
                           type: NUMERIC_EXPRESSION
@@ -960,7 +1101,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[1]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[1]
                   negate: true
 # double-negation of IN (<value list>) operator with single value
 >SELECT * FROM t1 WHERE NOT a NOT IN (1)
@@ -994,7 +1138,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     negate: true
                     values:
                       - value_expression:
@@ -1005,7 +1152,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[1]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[1]
                   negate: true
 # IN (<value list>) operator with multiple value
 >SELECT * FROM t1 WHERE a IN (1, 2, 3)
@@ -1039,7 +1189,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     values:
                       - value_expression:
                           type: NUMERIC_EXPRESSION
@@ -1049,7 +1202,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[1]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[1]
                       - value_expression:
                           type: NUMERIC_EXPRESSION
                           numeric_expression:
@@ -1058,7 +1214,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[2]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[2]
                       - value_expression:
                           type: NUMERIC_EXPRESSION
                           numeric_expression:
@@ -1067,7 +1226,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[3]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[3]
 # IN (<value list>) operator with complex value expressions
 >SELECT * FROM t1 WHERE a IN (1 - b, CHAR_LENGTH(b))
 statements:
@@ -1100,7 +1262,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     values:
                       - value_expression:
                           type: NUMERIC_EXPRESSION
@@ -1111,7 +1276,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
                             op: SUBTRACT
                             right:
                               term:
@@ -1119,7 +1287,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[b]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: b
                       - value_expression:
                           type: NUMERIC_EXPRESSION
                           numeric_expression:
@@ -1163,7 +1334,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     query:
                       selected_columns:
                         - derived_column:
@@ -1175,7 +1349,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1_a]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1_a
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1210,7 +1387,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1_id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1_id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1235,7 +1415,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -1249,7 +1432,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
 # NOT EXISTS (<subquery>) predicate
 >SELECT * FROM t1 WHERE NOT EXISTS (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -1280,7 +1466,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1_id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1_id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1305,7 +1494,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -1319,7 +1511,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
                     negate: true
 # <row> MATCH (<subquery>) predicate
 >SELECT * FROM t1 WHERE id MATCH (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
@@ -1353,7 +1548,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[id]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: id
                     query:
                       selected_columns:
                         - derived_column:
@@ -1365,7 +1563,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1_id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1_id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1390,7 +1591,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -1404,7 +1608,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
 # <row> MATCH (<subquery>) predicate explicit FULL
 >SELECT * FROM t1 WHERE id MATCH FULL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -1437,7 +1644,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[id]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: id
                     query:
                       selected_columns:
                         - derived_column:
@@ -1449,7 +1659,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1_id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1_id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1474,7 +1687,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -1488,7 +1704,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
 # <row> MATCH (<subquery>) predicate with UNIQUE
 >SELECT * FROM t1 WHERE id MATCH UNIQUE (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -1521,7 +1740,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[id]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: id
                     unique: true
                     query:
                       selected_columns:
@@ -1534,7 +1756,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1_id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1_id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1559,7 +1784,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -1573,7 +1801,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
 # <row> MATCH (<subquery>) predicate explicit PARTIAL
 >SELECT * FROM t1 WHERE id MATCH PARTIAL (SELECT t1_id FROM t2 WHERE t1_id = t1.id)
 statements:
@@ -1606,7 +1837,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[id]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: id
                     partial: true
                     query:
                       selected_columns:
@@ -1619,7 +1853,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1_id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1_id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1644,7 +1881,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -1658,7 +1898,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
 # LIKE predicate with simple column comparison with string
 >SELECT * FROM t1 WHERE a LIKE 's%'
 statements:
@@ -1691,7 +1934,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     pattern:
                       character_expression:
                         factors:
@@ -1729,7 +1975,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     pattern:
                       character_expression:
                         factors:
@@ -1772,7 +2021,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     pattern:
                       character_expression:
                         factors:
@@ -1815,7 +2067,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1.start]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1.start
                           - type: VALUE_EXPRESSION
                             value_expression:
                               type: NUMERIC_EXPRESSION
@@ -1825,7 +2080,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t1.end]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t1.end
                     right:
                       row_value_constructor:
                         type: LIST
@@ -1839,7 +2097,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t2.start]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t2.start
                           - type: VALUE_EXPRESSION
                             value_expression:
                               type: NUMERIC_EXPRESSION
@@ -1849,7 +2110,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t2.end]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t2.end
 # the UNIQUE predicate returns a match when the correlation returns one and
 # only one row
 >SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
@@ -1881,7 +2145,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t2.id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t2.id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1906,7 +2173,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t2.t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t2.t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -1920,7 +2190,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
 # negated UNIQUE predicate
 >SELECT * FROM t1 WHERE NOT UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id);
 statements:
@@ -1951,7 +2224,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t2.id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t2.id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -1976,7 +2252,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t2.t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t2.t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -1990,7 +2269,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
                     negate: true
 # Combine EXISTS and UNIQUE predicate
 >SELECT * FROM t1 WHERE UNIQUE (SELECT t2.id FROM t2 WHERE t2.t1_id = t1.id) AND EXISTS (SELECT t3.id FROM t3 WHERE t3.t1_id = t1.id);
@@ -2022,7 +2304,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t2.id]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t2.id
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -2047,7 +2332,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t2.t1_id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t2.t1_id
                                   right:
                                     row_value_constructor:
                                       type: ELEMENT
@@ -2061,7 +2349,10 @@ statements:
                                                 factor:
                                                   primary:
                                                     type: VALUE
-                                                    value: column-reference[t1.id]
+                                                    value:
+                                                      primary:
+                                                        type: COLUMN_REFERENCE
+                                                        column_reference: t1.id
                   and:
                     factor:
                       predicate:
@@ -2077,7 +2368,10 @@ statements:
                                         factor:
                                           primary:
                                             type: VALUE
-                                            value: column-reference[t3.id]
+                                            value:
+                                              primary:
+                                                type: COLUMN_REFERENCE
+                                                column_reference: t3.id
                           referenced_tables:
                             - type: TABLE
                               table:
@@ -2102,7 +2396,10 @@ statements:
                                                     factor:
                                                       primary:
                                                         type: VALUE
-                                                        value: column-reference[t3.t1_id]
+                                                        value:
+                                                          primary:
+                                                            type: COLUMN_REFERENCE
+                                                            column_reference: t3.t1_id
                                       right:
                                         row_value_constructor:
                                           type: ELEMENT
@@ -2116,7 +2413,10 @@ statements:
                                                     factor:
                                                       primary:
                                                         type: VALUE
-                                                        value: column-reference[t1.id]
+                                                        value:
+                                                          primary:
+                                                            type: COLUMN_REFERENCE
+                                                            column_reference: t1.id
 # quantified comparison predicates are like comparison predicates with an
 # ANY|ALL|SOME quantifier
 >SELECT * FROM t1 WHERE t1.start > ALL (SELECT t2.start FROM t2)
@@ -2151,7 +2451,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[t1.start]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: t1.start
                     quantifier: ALL
                     query:
                       selected_columns:
@@ -2164,7 +2467,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t2.start]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t2.start
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -2202,7 +2508,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[t1.start]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: t1.start
                     quantifier: ANY
                     query:
                       selected_columns:
@@ -2215,7 +2524,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t2.start]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t2.start
                       referenced_tables:
                         - type: TABLE
                           table:
@@ -2253,7 +2565,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[t1.start]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: t1.start
                     quantifier: ANY
                     query:
                       selected_columns:
@@ -2266,7 +2581,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[t2.start]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: t2.start
                       referenced_tables:
                         - type: TABLE
                           table:

--- a/tests/grammar/ansi-92/row-value-constructors.test
+++ b/tests/grammar/ansi-92/row-value-constructors.test
@@ -100,7 +100,7 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: (column-reference[a])
+                                      value: parenthesized-value-expression[column-reference[a]]
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -114,7 +114,7 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: (column-reference[b])
+                                      value: parenthesized-value-expression[column-reference[b]]
 # scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2)
 statements:

--- a/tests/grammar/ansi-92/row-value-constructors.test
+++ b/tests/grammar/ansi-92/row-value-constructors.test
@@ -32,7 +32,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[a]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: a
                           - type: VALUE_EXPRESSION
                             value_expression:
                               type: NUMERIC_EXPRESSION
@@ -42,7 +45,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[b]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: b
                     right:
                       row_value_constructor:
                         type: LIST
@@ -56,7 +62,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[b]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: b
                           - type: VALUE_EXPRESSION
                             value_expression:
                               type: NUMERIC_EXPRESSION
@@ -66,7 +75,10 @@ statements:
                                     factor:
                                       primary:
                                         type: VALUE
-                                        value: column-reference[a]
+                                        value:
+                                          primary:
+                                            type: COLUMN_REFERENCE
+                                            column_reference: a
 # Single-value row value constructor lists are OK too
 >SELECT * FROM t1 WHERE (a) = (b)
 statements:
@@ -100,7 +112,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: parenthesized-value-expression[column-reference[a]]
+                                      value:
+                                        primary:
+                                          type: PARENTHESIZED_VALUE_EXPRESSION
+                                          parenthesized_value_expression: column-reference[a]
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -114,7 +129,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: parenthesized-value-expression[column-reference[b]]
+                                      value:
+                                        primary:
+                                          type: PARENTHESIZED_VALUE_EXPRESSION
+                                          parenthesized_value_expression: column-reference[b]
 # scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2)
 statements:
@@ -148,7 +166,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -162,8 +183,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: scalar-subquery[
-query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
+                                      value:
+                                        primary:
+                                          type: SCALAR_SUBQUERY
+                                          scalar_subquery: query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]
 # scalar subquery inside another scalar subquery
 >SELECT * FROM t1 WHERE a = (SELECT b FROM t2 WHERE b = (SELECT c FROM t3))
 statements:
@@ -197,7 +220,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[a]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: a
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -211,9 +237,11 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: scalar-subquery[
-query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2 where[column-reference[b] = scalar-subquery[
-query[selected-columns[column-reference[c]] table-expression[referenced-tables[t3]]]]]]]
+                                      value:
+                                        primary:
+                                          type: SCALAR_SUBQUERY
+                                          scalar_subquery: query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2 where[column-reference[b] = scalar-subquery[
+query[selected-columns[column-reference[c]] table-expression[referenced-tables[t3]]]]]]
 # scalar subquery with correlation and alias
 >SELECT * FROM t1 WHERE num_t2 = (SELECT COUNT(*) FROM t2 WHERE t2.t1_id = t1.id)
 statements:
@@ -247,7 +275,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: column-reference[num_t2]
+                                      value:
+                                        primary:
+                                          type: COLUMN_REFERENCE
+                                          column_reference: num_t2
                     right:
                       row_value_constructor:
                         type: ELEMENT
@@ -261,5 +292,7 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: scalar-subquery[
-query[selected-columns[COUNT(*)] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]]
+                                      value:
+                                        primary:
+                                          type: SCALAR_SUBQUERY
+                                          scalar_subquery: query[selected-columns[COUNT(*)] table-expression[referenced-tables[t2 where[column-reference[t2.t1_id] = column-reference[t1.id]]]]

--- a/tests/grammar/ansi-92/string-expressions.test
+++ b/tests/grammar/ansi-92/string-expressions.test
@@ -14,7 +14,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: literal['a']
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: literal['a']
         referenced_tables:
           - type: TABLE
             table:
@@ -35,7 +38,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: literal['motorček']
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: literal['motorček']
         referenced_tables:
           - type: TABLE
             table:
@@ -56,7 +62,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: literal['01000101101']
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: literal['01000101101']
         referenced_tables:
           - type: TABLE
             table:
@@ -77,7 +86,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: literal['FE1CD34A']
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: literal['FE1CD34A']
         referenced_tables:
           - type: TABLE
             table:
@@ -98,8 +110,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: scalar-subquery[
-query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]]
+                          value:
+                            primary:
+                              type: SCALAR_SUBQUERY
+                              scalar_subquery: query[selected-columns[column-reference[b]] table-expression[referenced-tables[t2]]
         referenced_tables:
           - type: TABLE
             table:
@@ -120,7 +134,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: parameter[name]
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: parameter[name]
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -130,7 +147,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: parameter[name_long]
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: parameter[name_long]
           - derived_column:
               value_expression:
                 type: NUMERIC_EXPRESSION
@@ -140,7 +160,10 @@ statements:
                       factor:
                         primary:
                           type: VALUE
-                          value: parameter[?]
+                          value:
+                            primary:
+                              type: UNSIGNED_VALUE_SPECIFICATION
+                              unsigned_value_specification: parameter[?]
         referenced_tables:
           - type: TABLE
             table:
@@ -232,7 +255,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
         referenced_tables:
           - type: TABLE
             table:
@@ -264,7 +290,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[1]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[1]
                           for_length:
                             numeric_expression:
                               term:
@@ -272,7 +301,10 @@ statements:
                                   factor:
                                     primary:
                                       type: VALUE
-                                      value: literal[2]
+                                      value:
+                                        primary:
+                                          type: UNSIGNED_VALUE_SPECIFICATION
+                                          unsigned_value_specification: literal[2]
         referenced_tables:
           - type: TABLE
             table:

--- a/tests/grammar/ansi-92/table-references.test
+++ b/tests/grammar/ansi-92/table-references.test
@@ -63,7 +63,10 @@ statements:
                               factor:
                                 primary:
                                   type: VALUE
-                                  value: column-reference[a]
+                                  value:
+                                    primary:
+                                      type: COLUMN_REFERENCE
+                                      column_reference: a
                   - derived_column:
                       value_expression:
                         type: NUMERIC_EXPRESSION
@@ -73,7 +76,10 @@ statements:
                               factor:
                                 primary:
                                   type: VALUE
-                                  value: column-reference[b]
+                                  value:
+                                    primary:
+                                      type: COLUMN_REFERENCE
+                                      column_reference: b
                 referenced_tables:
                   - type: TABLE
                     table:

--- a/tests/grammar/ansi-92/update.test
+++ b/tests/grammar/ansi-92/update.test
@@ -34,7 +34,10 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: column-reference[b]
+                                    value:
+                                      primary:
+                                        type: COLUMN_REFERENCE
+                                        column_reference: b
                   right:
                     row_value_constructor:
                       type: ELEMENT
@@ -48,4 +51,7 @@ statements:
                                 factor:
                                   primary:
                                     type: VALUE
-                                    value: literal[2]
+                                    value:
+                                      primary:
+                                        type: UNSIGNED_VALUE_SPECIFICATION
+                                        unsigned_value_specification: literal[2]


### PR DESCRIPTION
I made a silly mistake in the INSERT statement parser resulting from a
misreading of the SQL-92 EBNF grammar for the INSERT statement. There is
no such thing as an INSERT_SELECT statement type. An INSERT statement
always has a `<query expression>` component. It's just that with the
INSERT ..  VALUES (...) style statement, the VALUES (...) clause *is* a
`<query expression>`. The VALUE (...) clause is called a `<table value
constructor>` and is a type of `<non join query primary>`.

We fix that parsing issue here and rename the value_subexpression_t to 
parenthesized_value_expression_t since that's what later SQL standards call it.