### PR TITLE
split out various table_reference_t parsers and parts

### DIFF
--- a/libsqltoast/include/sqltoast/print.h
+++ b/libsqltoast/include/sqltoast/print.h
@@ -96,7 +96,7 @@ std::ostream& operator<< (std::ostream& out, const interval_term_t& tern);
 std::ostream& operator<< (std::ostream& out, const interval_value_expression_t& ve);
 std::ostream& operator<< (std::ostream& out, const join_specification_t& js);
 std::ostream& operator<< (std::ostream& out, const joined_table_query_expression_t& qe);
-std::ostream& operator<< (std::ostream& out, const joined_table_t& jt);
+std::ostream& operator<< (std::ostream& out, const join_target_t& jt);
 std::ostream& operator<< (std::ostream& out, const length_expression_t& le);
 std::ostream& operator<< (std::ostream& out, const non_join_query_expression_t& qe);
 std::ostream& operator<< (std::ostream& out, const non_join_query_primary_t& primary);

--- a/libsqltoast/include/sqltoast/query.h
+++ b/libsqltoast/include/sqltoast/query.h
@@ -116,10 +116,9 @@ typedef struct non_join_query_expression : query_expression_t {
 } non_join_query_expression_t;
 
 typedef struct joined_table_query_expression : query_expression_t {
-    // Guaranteed to be static_castable to joined_table_t
-    std::unique_ptr<joined_table_t> joined_table;
+    std::unique_ptr<table_reference_t> joined_table;
     joined_table_query_expression(
-            std::unique_ptr<joined_table_t>& joined_table) :
+            std::unique_ptr<table_reference_t>& joined_table) :
         query_expression_t(QUERY_EXPRESSION_TYPE_JOINED_TABLE),
         joined_table(std::move(joined_table))
     {}

--- a/libsqltoast/include/sqltoast/table_reference.h
+++ b/libsqltoast/include/sqltoast/table_reference.h
@@ -64,13 +64,13 @@ typedef struct table : table_reference_t {
 
 struct query_expression;
 typedef struct derived_table : table_reference_t {
-    lexeme_t table_name;
+    correlation_spec_t correlation_spec;
     std::unique_ptr<struct query_expression> query;
     derived_table(
             lexeme_t& table_name,
             std::unique_ptr<struct query_expression>& query) :
         table_reference_t(TABLE_REFERENCE_TYPE_DERIVED_TABLE),
-        table_name(table_name),
+        correlation_spec(table_name),
         query(std::move(query))
     {}
 } derived_table_t;

--- a/libsqltoast/src/parser/parse.h
+++ b/libsqltoast/src/parser/parse.h
@@ -143,10 +143,6 @@ bool parse_non_join_query_primary(
         parse_context_t& ctx,
         token_t& cur_tok,
         std::unique_ptr<non_join_query_primary_t>& out);
-bool parse_joined_table(
-        parse_context_t& ctx,
-        token_t& cur_tok,
-        std::unique_ptr<joined_table_t>& out);
 
 // Returns true if a query specification can be parsed. If true, the out
 // argument will contain a new pointer to a query_specification_t.
@@ -170,6 +166,10 @@ bool parse_table_reference(
         token_t& cur_tok,
         std::unique_ptr<table_reference_t>& out);
 bool parse_derived_table(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::unique_ptr<table_reference_t>& out);
+bool parse_joined_table(
         parse_context_t& ctx,
         token_t& cur_tok,
         std::unique_ptr<table_reference_t>& out);

--- a/libsqltoast/src/parser/parse.h
+++ b/libsqltoast/src/parser/parse.h
@@ -169,6 +169,10 @@ bool parse_table_reference(
         parse_context_t& ctx,
         token_t& cur_tok,
         std::unique_ptr<table_reference_t>& out);
+bool parse_derived_table(
+        parse_context_t& ctx,
+        token_t& cur_tok,
+        std::unique_ptr<table_reference_t>& out);
 
 // Returns true if a search condition could be parsed. If true, the out
 // argument will have a new pointer to a search_condition_t added to it.

--- a/libsqltoast/src/print/table_reference.cc
+++ b/libsqltoast/src/print/table_reference.cc
@@ -42,7 +42,7 @@ std::ostream& operator<< (std::ostream& out, const table_t& t) {
 }
 
 std::ostream& operator<< (std::ostream& out, const derived_table_t& dt) {
-    out << "<derived table> AS " << dt.table_name;
+    out << "<derived table> AS " << dt.correlation_spec.alias;
     return out;
 }
 

--- a/libsqltoast/src/print/table_reference.cc
+++ b/libsqltoast/src/print/table_reference.cc
@@ -36,9 +36,8 @@ std::ostream& operator<< (std::ostream& out, const table_reference_t& tr) {
 
 std::ostream& operator<< (std::ostream& out, const table_t& t) {
     out << std::string(t.table_name.start, t.table_name.end);
-    if (t.has_alias()) {
-        out << " AS " << std::string(t.alias.start, t.alias.end);
-    }
+    if (t.has_alias())
+        out << " AS " << t.correlation_spec->alias;
     return out;
 }
 

--- a/libsqltoast/src/print/table_reference.cc
+++ b/libsqltoast/src/print/table_reference.cc
@@ -23,14 +23,9 @@ std::ostream& operator<< (std::ostream& out, const table_reference_t& tr) {
                 out << dt;
             }
             break;
-        case TABLE_REFERENCE_TYPE_JOINED_TABLE:
-            {
-                const joined_table_t& jt =
-                    static_cast<const joined_table_t&>(tr);
-                out << jt;
-            }
-            break;
     }
+    if (tr.joined)
+        out << *tr.joined;
     return out;
 }
 
@@ -46,7 +41,7 @@ std::ostream& operator<< (std::ostream& out, const derived_table_t& dt) {
     return out;
 }
 
-std::ostream& operator<< (std::ostream& out, const joined_table_t& jt) {
+std::ostream& operator<< (std::ostream& out, const join_target_t& jt) {
     switch (jt.join_type) {
         case JOIN_TYPE_INNER:
             out << "inner-join[";
@@ -72,9 +67,9 @@ std::ostream& operator<< (std::ostream& out, const joined_table_t& jt) {
         default:
             break;
     }
-    out << *jt.left << ',' << *jt.right;
-    if (jt.spec)
-        out << *jt.spec;
+    out << *jt.table_ref;
+    if (jt.join_spec)
+        out << *jt.join_spec;
     out << ']';
     return out;
 }

--- a/sqltoaster/fill.h
+++ b/sqltoaster/fill.h
@@ -57,7 +57,7 @@ void fill(mapping_t& node, const sqltoast::interval_term_t& term);
 void fill(mapping_t& node, const sqltoast::interval_value_expression_t& ie);
 void fill(mapping_t& node, const sqltoast::join_specification_t& spec);
 void fill(mapping_t& node, const sqltoast::joined_table_query_expression_t& qe);
-void fill(mapping_t& node, const sqltoast::joined_table_t& jt);
+void fill(mapping_t& node, const sqltoast::join_target_t& jt);
 void fill(mapping_t& node, const sqltoast::length_expression_t& expr);
 void fill(mapping_t& node, const sqltoast::like_predicate_t& pred);
 void fill(mapping_t& node, const sqltoast::match_predicate_t& pred);

--- a/sqltoaster/node/statement.cc
+++ b/sqltoaster/node/statement.cc
@@ -404,7 +404,7 @@ void fill(mapping_t& node, const sqltoast::table_reference_t& tr) {
 void fill(mapping_t& node, const sqltoast::table_t& t) {
     node.setattr("name", t.table_name);
     if (t.has_alias())
-        node.setattr("alias", t.alias);
+        node.setattr("alias", t.correlation_spec->alias);
 }
 
 void fill(mapping_t& node, const sqltoast::derived_table_t& t) {

--- a/sqltoaster/node/statement.cc
+++ b/sqltoaster/node/statement.cc
@@ -408,9 +408,9 @@ void fill(mapping_t& node, const sqltoast::table_t& t) {
 }
 
 void fill(mapping_t& node, const sqltoast::derived_table_t& t) {
-    // NOTE(jaypipes): derived tables don't have aliases because they are
-    // required to be named with AS <table name>
-    node.setattr("name", t.table_name);
+    // NOTE(jaypipes): derived tables always have a <correlation spec> which
+    // contains an alias attribute
+    node.setattr("name", t.correlation_spec.alias);
     std::unique_ptr<node_t> query_node = std::make_unique<mapping_t>();
     mapping_t& query_map = static_cast<mapping_t&>(*query_node);
     fill(query_map, *t.query);

--- a/tests/grammar/ansi-92/joins.test
+++ b/tests/grammar/ansi-92/joins.test
@@ -13,14 +13,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: CROSS_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -33,14 +31,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: INNER_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -91,14 +87,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: INNER_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -149,14 +143,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: INNER_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -169,14 +161,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: LEFT_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -227,14 +217,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: LEFT_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -285,14 +273,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: RIGHT_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -343,14 +329,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: RIGHT_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -401,14 +385,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: FULL_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -459,14 +441,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: FULL_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -517,14 +497,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: INNER_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -540,14 +518,12 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: NATURAL_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
@@ -560,14 +536,86 @@ statements:
         selected_columns:
           - asterisk: true
         referenced_tables:
-          - type: JOINED_TABLE
-            joined_table:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
               type: UNION_JOIN
-              left:
-                type: TABLE
-                table:
-                  name: t1
-              right:
+              table_reference:
                 type: TABLE
                 table:
                   name: t2
+# JOIN of normal table to derived table
+>SELECT * FROM t1 LEFT JOIN (SELECT t1_id FROM t2 GROUP BY t1_id) AS d2 ON t1.id = d2.t1_id
+statements:
+  - type: SELECT
+    select_statement:
+      query:
+        selected_columns:
+          - asterisk: true
+        referenced_tables:
+          - type: TABLE
+            table:
+              name: t1
+            joined:
+              type: LEFT_JOIN
+              table_reference:
+                type: DERIVED_TABLE
+                derived_table:
+                  name: d2
+                  query:
+                    selected_columns:
+                      - type: NUMERIC_EXPRESSION
+                        numeric_expression:
+                          left:
+                            left:
+                              primary:
+                                type: VALUE
+                                value:
+                                  primary:
+                                    type: COLUMN_REFERENCE
+                                    column_reference: t1_id
+                    referenced_tables:
+                      - type: TABLE
+                        table:
+                          name: t2
+                    group_by:
+                      - t1_id
+              specification:
+                on:
+                  terms:
+                    - factor:
+                        predicate:
+                          type: COMPARISON
+                          comparison_predicate:
+                            op: EQUAL
+                            left:
+                              type: ELEMENT
+                              element:
+                                type: VALUE_EXPRESSION
+                                value_expression:
+                                  type: NUMERIC_EXPRESSION
+                                  numeric_expression:
+                                    left:
+                                      left:
+                                        primary:
+                                          type: VALUE
+                                          value:
+                                            primary:
+                                              type: COLUMN_REFERENCE
+                                              column_reference: t1.id
+                            right:
+                              type: ELEMENT
+                              element:
+                                type: VALUE_EXPRESSION
+                                value_expression:
+                                  type: NUMERIC_EXPRESSION
+                                  numeric_expression:
+                                    left:
+                                      left:
+                                        primary:
+                                          type: VALUE
+                                          value:
+                                            primary:
+                                              type: COLUMN_REFERENCE
+                                              column_reference: d2.t1_id


### PR DESCRIPTION
I realized that the way I was structuring the table_reference_t
hierarchy, with joined_table_t being its own subtype of
table_reference_t, was wrong. In actuality, a <joined table> parse
element is nothing more than a normal or derived table with another
table_reference joined to it.

Therefore, I've restructured table_reference_t to have an optional
std::unique_ptr<join_target_t> which describes the joined table
reference, if found.