### PR TITLE
Add ST_DBG macro and initial calls

### DIFF
--- a/libsqltoast/include/sqltoast/debug.h
+++ b/libsqltoast/include/sqltoast/debug.h
@@ -1,0 +1,61 @@
+/*
+ * Use and distribution licensed under the Apache license version 2.
+ *
+ * See the COPYING file in the root project directory for full text.
+ */
+
+#ifndef SQLTOAST_DEBUG_H
+#define SQLTOAST_DEBUG_H
+
+#if defined(SQLTOAST_DEBUG)
+
+#include <iostream>
+
+#include <sqltoast/print.h>
+
+namespace sqltoast {
+
+// The following code was yanked from
+// https://blog.galowicz.de/2016/02/20/short_file_macro/
+using cstr = const char* const;
+
+static constexpr cstr past_last_slash(cstr str, cstr last_slash)
+{
+    return *str == '\0' ? last_slash :
+           *str == '/'  ? past_last_slash(str + 1, str + 1) :
+           past_last_slash(str + 1, last_slash);
+}
+
+static constexpr cstr past_last_slash(cstr str)
+{
+    return past_last_slash(str, str);
+}
+
+#define __SHORT_FILE__ ({constexpr cstr sf__ {past_last_slash(__FILE__)}; sf__;})
+
+template<typename T>
+void debug_print(const T& v) {
+    std::cerr << v << std::endl;
+}
+template<typename T, typename...Args>
+void debug_print(const T& v, Args... rest) {
+    std::cerr << v;
+    debug_print(rest...);
+}
+template<typename... Args>
+void debug_print(const char *file, int line_no, const char *fn, Args... args) {
+    std::cerr << file << '[' << line_no << "] " << fn << "(): ";
+    debug_print(args...);
+}
+
+} // namespace sqltoast
+
+#define ST_DBG(...) sqltoast::debug_print(__SHORT_FILE__, __LINE__, __func__, __VA_ARGS__)
+
+#else  // defined(SQLTOAST_DEBUG)
+
+#define ST_DBG(fmt, ...)
+
+#endif // defined(SQLTOAST_DEBUG)
+
+#endif /* SQLTOAST_DEBUG_H */

--- a/libsqltoast/include/sqltoast/sqltoast.h.in
+++ b/libsqltoast/include/sqltoast/sqltoast.h.in
@@ -30,6 +30,8 @@
 #include "query.h"
 #include "statement.h"
 
+#include "debug.h"
+
 namespace sqltoast {
 
 // Dialects of SQL that can be parsed by sqltoast

--- a/libsqltoast/src/parser/value.cc
+++ b/libsqltoast/src/parser/value.cc
@@ -21,31 +21,47 @@ bool parse_numeric_term(
     symbol_t cur_sym = cur_tok.symbol;
     std::unique_ptr<numeric_factor_t> factor;
     std::unique_ptr<numeric_factor_t> operand;
-    if (! parse_numeric_factor(ctx, cur_tok, factor))
+    ST_DBG("before parse_numeric_factor(factor). cur_tok is ", cur_tok);
+    if (! parse_numeric_factor(ctx, cur_tok, factor)) {
+        ST_DBG("parse_numeric_factor(factor) -> false. "
+               "returning false from parse_numeric_term()");
         return false;
+    }
+    ST_DBG("parse_numeric_term(factor) -> true. cur_tok is ", cur_tok);
     goto ensure_term;
 optional_operator:
     // Check to see if we've currently got a * or a / arithmetic operator as
     // our current symbol. If so, that indicates we should expect to parse
     // another numeric factor as an operand to the arithmetic equation.
+    ST_DBG("check cur_tok ", cur_tok, " is optional operator");
     cur_sym = cur_tok.symbol;
     if (cur_sym == SYMBOL_ASTERISK) {
         cur_tok = lex.next();
+        ST_DBG("found ASTERISK operator. expect parse_numeric_factor(operand). "
+               "cur_tok is ", cur_tok);
         if (! parse_numeric_factor(ctx, cur_tok, operand)) {
+            ST_DBG("parse_numeric_factor(operand) -> false. SYNTAX ERROR.");
             if (ctx.result.code == PARSE_SYNTAX_ERROR)
                 return false;
             goto err_expect_numeric_factor;
         }
+        ST_DBG("parse_numeric_factor(operand) -> true. "
+               "returning true from parse_numeric_term()");
         if (out)
             out->multiply(operand);
         return true;
     } else if (cur_sym == SYMBOL_SOLIDUS) {
         cur_tok = lex.next();
+        ST_DBG("found SOLIDUS operator. expect parse_numeric_factor(operand). "
+               "cur_tok is ", cur_tok);
         if (! parse_numeric_factor(ctx, cur_tok, operand)) {
+            ST_DBG("parse_numeric_factor(operand) -> false. SYNTAX ERROR.");
             if (ctx.result.code == PARSE_SYNTAX_ERROR)
                 return false;
             goto err_expect_numeric_factor;
         }
+        ST_DBG("parse_numeric_factor(operand) -> true. "
+               "returning true from parse_numeric_term()");
         if (out)
             out->divide(operand);
         return true;


### PR DESCRIPTION
Adds a new `ST_DBG` macro that prints out a variable number of arguments to std::cerr along with the short filename and line number of the call site.

The first parser to get `ST_DBG`'iified is `parse_numeric_term()`. Other parsers will come shortly.

Issue #108 